### PR TITLE
Resolve build problems with "vcpython27"

### DIFF
--- a/math_msvc_compatibility.h
+++ b/math_msvc_compatibility.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2015, Michael Boyle
+// See LICENSE file for details: <https://github.com/moble/quaternion/blob/master/LICENSE>
+
+#ifndef __MATH_MSVC_COMPATIBILITY_H__
+#define __MATH_MSVC_COMPATIBILITY_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define _USE_MATH_DEFINES
+#include <float.h>
+#include <math.h>
+
+#ifdef isnan
+#undef isnan
+#endif
+
+#ifdef isinf
+#undef isinf
+#endif
+
+#ifdef isfinite
+#undef isfinite
+#endif
+
+#ifdef copysign
+#undef copysign
+#endif
+
+static __inline int isnan(double x) {
+  return _isnan(x);
+}
+
+static __inline int isinf(double x) {
+  return !_finite(x);
+}
+
+static __inline int isfinite(double x) {
+  return _finite(x);
+}
+
+static __inline double copysign(double x, double y) {
+  return _copysign(x, y);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __MATH_MSVC_COMPATIBILITY_H__

--- a/numpy_quaternion.c
+++ b/numpy_quaternion.c
@@ -804,6 +804,7 @@ static npy_bool
 QUATERNION_nonzero (char *ip, PyArrayObject *ap)
 {
   quaternion q;
+  quaternion zero = {0,0,0,0};
   if (ap == NULL || PyArray_ISBEHAVED_RO(ap)) {
     q = *(quaternion *)ip;
   }
@@ -816,7 +817,7 @@ QUATERNION_nonzero (char *ip, PyArrayObject *ap)
     descr->f->copyswap(&q.z, ip+24, !PyArray_ISNOTSWAPPED(ap), NULL);
     Py_DECREF(descr);
   }
-  return (npy_bool) !quaternion_equal(q, (quaternion) {0,0,0,0});
+  return (npy_bool) !quaternion_equal(q, zero);
 }
 
 static void

--- a/numpy_quaternion.c
+++ b/numpy_quaternion.c
@@ -32,7 +32,7 @@ static NPY_INLINE int PyInt_Check(PyObject *op) {
 
 // The basic python object holding a quaternion
 typedef struct {
-  PyObject_HEAD;
+  PyObject_HEAD
   quaternion obval;
 } PyQuaternion;
 

--- a/numpy_quaternion.c
+++ b/numpy_quaternion.c
@@ -217,6 +217,7 @@ QQ_BINARY_QUATERNION_RETURNER(copysign)
     NpyIter_IterNextFunc *in_iternext;                                  \
     NpyIter_IterNextFunc *out_iternext;                                 \
     quaternion p = {0};                                                 \
+    quaternion ** out_dataptr;                                          \
     PyQuaternion_AsQuaternion(p, a);                                    \
     out_array = PyArray_NewLikeArray(in_array, NPY_ANYORDER, quaternion_descr, 0); \
     if (out_array == NULL) return NULL;                                 \
@@ -236,7 +237,7 @@ QQ_BINARY_QUATERNION_RETURNER(copysign)
       NpyIter_Deallocate(out_iter);                                     \
       goto fail;                                                        \
     }                                                                   \
-    quaternion ** out_dataptr = (quaternion **) NpyIter_GetDataPtrArray(out_iter); \
+    out_dataptr = (quaternion **) NpyIter_GetDataPtrArray(out_iter);    \
     if(PyArray_EquivTypes(PyArray_DESCR((PyArrayObject*) b), quaternion_descr)) { \
       quaternion ** in_dataptr = (quaternion **) NpyIter_GetDataPtrArray(in_iter); \
       do {                                                              \

--- a/quaternion.c
+++ b/quaternion.c
@@ -12,7 +12,8 @@ quaternion_create_from_spherical_coords(double vartheta, double varphi) {
   double cp = cos(varphi/2.);
   double st = sin(vartheta/2.);
   double sp = sin(varphi/2.);
-  return (quaternion) {cp*ct, -sp*st, st*cp, sp*ct};
+  quaternion r = {cp*ct, -sp*st, st*cp, sp*ct};
+  return r;
 }
 
 quaternion
@@ -23,19 +24,22 @@ quaternion_create_from_euler_angles(double alpha, double beta, double gamma) {
   double sa = sin(alpha/2.);
   double sb = sin(beta/2.);
   double sc = sin(gamma/2.);
-  return (quaternion) {ca*cb*cc-sa*cb*sc, ca*sb*sc-sa*sb*cc, ca*sb*cc+sa*sb*sc, sa*cb*cc+ca*cb*sc};
+  quaternion r = {ca*cb*cc-sa*cb*sc, ca*sb*sc-sa*sb*cc, ca*sb*cc+sa*sb*sc, sa*cb*cc+ca*cb*sc};
+  return r;
 }
 
 quaternion
 quaternion_sqrt(quaternion q)
 {
-  double c;
   double absolute = quaternion_absolute(q);
   if(fabs(1+q.w/absolute)<_QUATERNION_EPS*absolute) {
-    return (quaternion) {0.0, 1.0, 0.0, 0.0};
+    quaternion r = {0.0, 1.0, 0.0, 0.0};
+    return r;
+  } else {
+    double c = sqrt(absolute/(2+2*q.w/absolute));
+    quaternion r = {(1.0+q.w/absolute)*c, q.x*c/absolute, q.y*c/absolute, q.z*c/absolute};
+    return r;
   }
-  c = sqrt(absolute/(2+2*q.w/absolute));
-  return (quaternion) {(1.0+q.w/absolute)*c, q.x*c/absolute, q.y*c/absolute, q.z*c/absolute};
 }
 
 quaternion
@@ -46,15 +50,21 @@ quaternion_log(quaternion q)
     if(q.w<0.0) {
       // fprintf(stderr, "Input quaternion(%.15g, %.15g, %.15g, %.15g) has no unique logarithm; returning one arbitrarily.", q.w, q.x, q.y, q.z);
       if(fabs(q.w+1)>_QUATERNION_EPS) {
-        return (quaternion) {log(-q.w), M_PI, 0., 0.};
+        quaternion r = {log(-q.w), M_PI, 0., 0.};
+        return r;
+      } else {
+        quaternion r = {0., M_PI, 0., 0.};
+        return r;
       }
-      return (quaternion) {0., M_PI, 0., 0.};
+    } else {
+      quaternion r = {log(q.w), 0., 0., 0.};
+      return r;
     }
-    return (quaternion) {log(q.w), 0., 0., 0.};
   } else {
     double v = atan2(b, q.w);
     double f = v/b;
-    return (quaternion) { log(q.w*q.w+b*b)/2.0, f*q.x, f*q.y, f*q.z };
+    quaternion r = { log(q.w*q.w+b*b)/2.0, f*q.x, f*q.y, f*q.z };
+    return r;
   }
 }
 
@@ -67,13 +77,16 @@ quaternion_scalar_power(double s, quaternion q)
   /* Unlike the quaternion^quaternion power, this is unambiguous. */
   if(s==0.0) { /* log(s)=-inf */
     if(! quaternion_nonzero(q)) {
-      return (quaternion) {1.0, 0.0, 0.0, 0.0}; /* consistent with python */
+      quaternion r = {1.0, 0.0, 0.0, 0.0}; /* consistent with python */
+      return r;
     } else {
-      return (quaternion) {0.0, 0.0, 0.0, 0.0}; /* consistent with python */
+      quaternion r = {0.0, 0.0, 0.0, 0.0}; /* consistent with python */
+      return r;
     }
   } else if(s<0.0) { /* log(s)=nan */
     // fprintf(stderr, "Input scalar (%.15g) has no unique logarithm; returning one arbitrarily.", s);
-    return quaternion_exp(quaternion_multiply(q, (quaternion) {log(-s), M_PI, 0, 0}));
+    quaternion t = {log(-s), M_PI, 0, 0};
+    return quaternion_exp(quaternion_multiply(q, t));
   }
   return quaternion_exp(quaternion_multiply_scalar(q, log(s)));
 }
@@ -85,8 +98,10 @@ quaternion_exp(quaternion q)
   if (vnorm > _QUATERNION_EPS) {
     double s = sin(vnorm) / vnorm;
     double e = exp(q.w);
-    return (quaternion) {e*cos(vnorm), e*s*q.x, e*s*q.y, e*s*q.z};
+    quaternion r = {e*cos(vnorm), e*s*q.x, e*s*q.y, e*s*q.z};
+    return r;
   } else {
-    return (quaternion) {exp(q.w), 0, 0, 0};
+    quaternion r = {exp(q.w), 0, 0, 0};
+    return r;
   }
 }

--- a/quaternion.c
+++ b/quaternion.c
@@ -1,7 +1,16 @@
 // Copyright (c) 2015, Michael Boyle
 // See LICENSE file for details: <https://github.com/moble/quaternion/blob/master/LICENSE>
 
-#include <math.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(_MSC_VER)
+  #include "math_msvc_compatibility.h"
+#else
+  #include <math.h>
+#endif
+
 #include <stdio.h>
 
 #include "quaternion.h"
@@ -105,3 +114,7 @@ quaternion_exp(quaternion q)
     return r;
   }
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/quaternion.h
+++ b/quaternion.h
@@ -122,73 +122,91 @@ extern "C" {
   quaternion quaternion_exp(quaternion q);
   static NPY_INLINE quaternion quaternion_normalized(quaternion q) {
     double q_abs = quaternion_absolute(q);
-    return (quaternion) {q.w/q_abs, q.x/q_abs, q.y/q_abs, q.z/q_abs};
+    quaternion r = {q.w/q_abs, q.x/q_abs, q.y/q_abs, q.z/q_abs};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_x_parity_conjugate(quaternion q) {
-    return (quaternion) {q.w, q.x, -q.y, -q.z};
+    quaternion r = {q.w, q.x, -q.y, -q.z};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_x_parity_symmetric_part(quaternion q) {
-    return (quaternion) {q.w, q.x, 0.0, 0.0};
+    quaternion r = {q.w, q.x, 0.0, 0.0};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_x_parity_antisymmetric_part(quaternion q) {
-    return (quaternion) {0.0, 0.0, q.y, q.z};
+    quaternion r = {0.0, 0.0, q.y, q.z};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_y_parity_conjugate(quaternion q) {
-    return (quaternion) {q.w, -q.x, q.y, -q.z};
+    quaternion r = {q.w, -q.x, q.y, -q.z};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_y_parity_symmetric_part(quaternion q) {
-    return (quaternion) {q.w, 0.0, q.y, 0.0};
+    quaternion r = {q.w, 0.0, q.y, 0.0};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_y_parity_antisymmetric_part(quaternion q) {
-    return (quaternion) {0.0, q.x, 0.0, q.z};
+    quaternion r = {0.0, q.x, 0.0, q.z};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_z_parity_conjugate(quaternion q) {
-    return (quaternion) {q.w, -q.x, -q.y, q.z};
+    quaternion r = {q.w, -q.x, -q.y, q.z};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_z_parity_symmetric_part(quaternion q) {
-    return (quaternion) {q.w, 0.0, 0.0, q.z};
+    quaternion r = {q.w, 0.0, 0.0, q.z};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_z_parity_antisymmetric_part(quaternion q) {
-    return (quaternion) {0.0, q.x, q.y, 0.0};
+    quaternion r = {0.0, q.x, q.y, 0.0};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_parity_conjugate(quaternion q) {
-    return (quaternion) {q.w, q.x, q.y, q.z};
+    quaternion r = {q.w, q.x, q.y, q.z};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_parity_symmetric_part(quaternion q) {
-    return (quaternion) {q.w, q.x, q.y, q.z};
+    quaternion r = {q.w, q.x, q.y, q.z};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_parity_antisymmetric_part(quaternion q) {
-    return (quaternion) {0.0, 0.0, 0.0, 0.0};
+    quaternion r = {0.0, 0.0, 0.0, 0.0};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_negative(quaternion q) {
-    return (quaternion) {-q.w, -q.x, -q.y, -q.z};
+    quaternion r = {-q.w, -q.x, -q.y, -q.z};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_conjugate(quaternion q) {
-    return (quaternion) {q.w, -q.x, -q.y, -q.z};
+    quaternion r = {q.w, -q.x, -q.y, -q.z};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_inverse(quaternion q) {
     double norm = quaternion_norm(q);
-    return (quaternion) {q.w/norm, -q.x/norm, -q.y/norm, -q.z/norm};
+    quaternion r = {q.w/norm, -q.x/norm, -q.y/norm, -q.z/norm};
+    return r;
   }
 
   // Quaternion-quaternion binary quaternion returners
   static NPY_INLINE quaternion quaternion_copysign(quaternion q1, quaternion q2) {
-    return (quaternion) {
+    quaternion r = {
       copysign(q1.w, q2.w),
       copysign(q1.x, q2.x),
       copysign(q1.y, q2.y),
       copysign(q1.z, q2.z)
     };
+    return r;
   }
 
   // Quaternion-quaternion/quaternion-scalar binary quaternion returners
   static NPY_INLINE quaternion quaternion_add(quaternion q1, quaternion q2) {
-    return (quaternion) {
+    quaternion r = {
       q1.w+q2.w,
       q1.x+q2.x,
       q1.y+q2.y,
       q1.z+q2.z,
     };
+    return r;
   }
   static NPY_INLINE void quaternion_inplace_add(quaternion* q1, quaternion q2) {
     q1->w += q2.w;
@@ -198,26 +216,29 @@ extern "C" {
     return;
   }
   static NPY_INLINE quaternion quaternion_scalar_add(double s, quaternion q) {
-    return (quaternion) {s+q.w, q.x, q.y, q.z};
+    quaternion r = {s+q.w, q.x, q.y, q.z};
+    return r;
   }
   static NPY_INLINE void quaternion_inplace_scalar_add(double s, quaternion* q) {
     q->w += s;
     return;
   }
   static NPY_INLINE quaternion quaternion_add_scalar(quaternion q, double s) {
-    return (quaternion) {s+q.w, q.x, q.y, q.z};
+    quaternion r = {s+q.w, q.x, q.y, q.z};
+    return r;
   }
   static NPY_INLINE void quaternion_inplace_add_scalar(quaternion* q, double s) {
     q->w += s;
     return;
   }
   static NPY_INLINE quaternion quaternion_subtract(quaternion q1, quaternion q2) {
-    return (quaternion) {
+    quaternion r = {
       q1.w-q2.w,
       q1.x-q2.x,
       q1.y-q2.y,
       q1.z-q2.z,
     };
+    return r;
   }
   static NPY_INLINE void quaternion_inplace_subtract(quaternion* q1, quaternion q2) {
     q1->w -= q2.w;
@@ -227,22 +248,25 @@ extern "C" {
     return;
   }
   static NPY_INLINE quaternion quaternion_scalar_subtract(double s, quaternion q) {
-    return (quaternion) {s-q.w, -q.x, -q.y, -q.z};
+    quaternion r = {s-q.w, -q.x, -q.y, -q.z};
+    return r;
   }
   static NPY_INLINE quaternion quaternion_subtract_scalar(quaternion q, double s) {
-    return (quaternion) {q.w-s, q.x, q.y, q.z};
+    quaternion r = {q.w-s, q.x, q.y, q.z};
+    return r;
   }
   static NPY_INLINE void quaternion_inplace_subtract_scalar(quaternion* q, double s) {
     q->w -= s;
     return;
   }
   static NPY_INLINE quaternion quaternion_multiply(quaternion q1, quaternion q2) {
-    return (quaternion) {
+    quaternion r = {
       q1.w*q2.w - q1.x*q2.x - q1.y*q2.y - q1.z*q2.z,
       q1.w*q2.x + q1.x*q2.w + q1.y*q2.z - q1.z*q2.y,
       q1.w*q2.y - q1.x*q2.z + q1.y*q2.w + q1.z*q2.x,
       q1.w*q2.z + q1.x*q2.y - q1.y*q2.x + q1.z*q2.w,
     };
+    return r;
   }
   static NPY_INLINE void quaternion_inplace_multiply(quaternion* q1a, quaternion q2) {
     quaternion q1 = *q1a;
@@ -253,7 +277,8 @@ extern "C" {
     return;
   }
   static NPY_INLINE quaternion quaternion_scalar_multiply(double s, quaternion q) {
-    return (quaternion) {s*q.w, s*q.x, s*q.y, s*q.z};
+    quaternion r = {s*q.w, s*q.x, s*q.y, s*q.z};
+    return r;
   }
   static NPY_INLINE void quaternion_inplace_scalar_multiply(double s, quaternion* q) {
     q->w *= s;
@@ -263,7 +288,8 @@ extern "C" {
     return;
   }
   static NPY_INLINE quaternion quaternion_multiply_scalar(quaternion q, double s) {
-    return (quaternion) {s*q.w, s*q.x, s*q.y, s*q.z};
+    quaternion r = {s*q.w, s*q.x, s*q.y, s*q.z};
+    return r;
   }
   static NPY_INLINE void quaternion_inplace_multiply_scalar(quaternion* q, double s) {
     q->w *= s;
@@ -274,12 +300,13 @@ extern "C" {
   }
   static NPY_INLINE quaternion quaternion_divide(quaternion q1, quaternion q2) {
     double q2norm = q2.w*q2.w + q2.x*q2.x + q2.y*q2.y + q2.z*q2.z;
-    return (quaternion) {
+    quaternion r = {
       (  q1.w*q2.w + q1.x*q2.x + q1.y*q2.y + q1.z*q2.z) / q2norm,
       (- q1.w*q2.x + q1.x*q2.w - q1.y*q2.z + q1.z*q2.y) / q2norm,
       (- q1.w*q2.y + q1.x*q2.z + q1.y*q2.w - q1.z*q2.x) / q2norm,
       (- q1.w*q2.z - q1.x*q2.y + q1.y*q2.x + q1.z*q2.w) / q2norm
     };
+    return r;
   }
   static NPY_INLINE void quaternion_inplace_divide(quaternion* q1a, quaternion q2) {
     double q2norm;
@@ -293,17 +320,19 @@ extern "C" {
   }
   static NPY_INLINE quaternion quaternion_scalar_divide(double s, quaternion q) {
     double qnorm = q.w*q.w + q.x*q.x + q.y*q.y + q.z*q.z;
-    return (quaternion) {
+    quaternion r = {
       ( s*q.w) / qnorm,
       (-s*q.x) / qnorm,
       (-s*q.y) / qnorm,
       (-s*q.z) / qnorm
     };
+    return r;
   }
   /* The following function is impossible, but listed for completeness: */
   /* static NPY_INLINE void quaternion_inplace_scalar_divide(double* sa, quaternion q2) { } */
   static NPY_INLINE quaternion quaternion_divide_scalar(quaternion q, double s) {
-    return (quaternion) {q.w/s, q.x/s, q.y/s, q.z/s};
+    quaternion r = {q.w/s, q.x/s, q.y/s, q.z/s};
+    return r;
   }
   static NPY_INLINE void quaternion_inplace_divide_scalar(quaternion* q, double s) {
     q->w /= s;
@@ -317,9 +346,11 @@ extern "C" {
     /* Other definitions may disagree due to non-commutativity. */
     if(! quaternion_nonzero(q)) { /* log(q)=-inf */
       if(! quaternion_nonzero(p)) {
-        return (quaternion) {1.0, 0.0, 0.0, 0.0}; /* consistent with python */
+        quaternion r = {1.0, 0.0, 0.0, 0.0}; /* consistent with python */
+        return r;
       } else {
-        return (quaternion) {0.0, 0.0, 0.0, 0.0}; /* consistent with python */
+        quaternion r = {0.0, 0.0, 0.0, 0.0}; /* consistent with python */
+        return r;
       }
     }
     return quaternion_exp(quaternion_multiply(quaternion_log(q), p));
@@ -341,9 +372,11 @@ extern "C" {
     /* Unlike the quaternion^quaternion power, this is unambiguous. */
     if(! quaternion_nonzero(q)) { /* log(q)=-inf */
       if(s==0) {
-        return (quaternion) {1.0, 0.0, 0.0, 0.0}; /* consistent with python */
+        quaternion r = {1.0, 0.0, 0.0, 0.0}; /* consistent with python */
+        return r;
       } else {
-        return (quaternion) {0.0, 0.0, 0.0, 0.0}; /* consistent with python */
+        quaternion r = {0.0, 0.0, 0.0, 0.0}; /* consistent with python */
+        return r;
       }
     }
     return quaternion_exp(quaternion_multiply_scalar(quaternion_log(q), s));

--- a/quaternion.h
+++ b/quaternion.h
@@ -8,6 +8,12 @@
 extern "C" {
 #endif
 
+  #if defined(_MSC_VER)
+    #include "math_msvc_compatibility.h"
+  #else
+    #include <math.h>
+  #endif
+
   #define _QUATERNION_EPS 1e-14
 
   #if defined(_MSC_VER)


### PR DESCRIPTION
This patch series should resolve most problems with building with [Microsoft Visual C++ Compiler for Python 2.7](https://www.microsoft.com/en-us/download/details.aspx?id=44266) (which `conda-build` recommends when builds fail on Windows). Most issues are due to the fact that MSVC++ 9 does not fully understand C99.

So far, I have **only tested this patch for building on Windows** 7 (x86-64) with this "MSVC++ 9 for Python 2.7" distribution.

This patch is intended to fix issue #23.