### PR TITLE
Simplify as_float_array

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -56,12 +56,7 @@ def as_float_array(a):
     array, but is otherwise the same shape.
 
     """
-    a = np.asarray(a, dtype=np.quaternion)
-    if a.ndim == 0:
-        return a[()].components
-    av = a.view(np.float)
-    av = av.reshape(a.shape + (4,))
-    return av
+    return np.asarray(a, dtype=np.quaternion).view((np.double, 4))
 
 
 def as_quat_array(a):


### PR DESCRIPTION
Use subdtypes, instead of manual reshaping
Use np.double to match the C code

Continuing from https://github.com/moble/quaternion/commit/f9a97856c4d098cdb9c993a74d8800b2bec2980b#commitcomment-22311594