### PR TITLE
Fix casting bug for arrays with more than one element

### DIFF
--- a/numpy_quaternion.c
+++ b/numpy_quaternion.c
@@ -1015,6 +1015,7 @@ QUATERNION_fillwithscalar(quaternion *buffer, npy_intp length, quaternion *value
       op->x = 0;                                                        \
       op->y = 0;                                                        \
       op->z = 0;                                                        \
+      op++;                                                             \
     }                                                                   \
   }
 MAKE_T_TO_QUATERNION(FLOAT, npy_float);


### PR DESCRIPTION
Before this patch, it seems that casting to quaternion only worked on single-element arrays (including scalars), because the casting functions never increment the output pointer (per https://docs.scipy.org/doc/numpy-1.14.0/user/c-info.beyond-basics.html#registering-a-casting-function).

This fix simply adds the pointer increment.

Behavior before fix (values come from unitialized memory):
```python
>>> import quaternion
>>> import numpy as np
>>> np.arange(3).astype(quaternion.quaternion)
array([quaternion(2, 0, 0, 0),
       quaternion(4.67375218337093e-310, 6.91863062385413e-310, 1.75631032264023e-152, 9.70158285078138e+189),
       quaternion(2.36255657307039e+232, 1.23558559545832e-259, 6.01347001699907e-154, 3.10361008473637e+175)], dtype=quaternion)
```

After fix, it is as expected:
```python
>>> import quaternion
>>> import numpy as np
>>> np.arange(3).astype(quaternion.quaternion)
array([quaternion(0, 0, 0, 0), quaternion(1, 0, 0, 0),
       quaternion(2, 0, 0, 0)], dtype=quaternion)
```