### PR TITLE
Make metric functions ufuncs for vectorization and type checking

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,8 +7,6 @@ import numpy as np
 
 from .numpy_quaternion import (quaternion, _eps,
                                from_spherical_coords, from_euler_angles,
-                               rotor_intrinsic_distance, rotor_chordal_distance,
-                               rotation_intrinsic_distance, rotation_chordal_distance,
                                slerp_evaluate, squad_evaluate,
                                # slerp_vectorized, squad_vectorized,
                                # slerp, squad,
@@ -45,6 +43,11 @@ one = np.quaternion(1, 0, 0, 0)
 x = np.quaternion(0, 1, 0, 0)
 y = np.quaternion(0, 0, 1, 0)
 z = np.quaternion(0, 0, 0, 1)
+
+rotor_intrinsic_distance = np.rotor_intrinsic_distance
+rotor_chordal_distance = np.rotor_chordal_distance
+rotation_intrinsic_distance = np.rotation_intrinsic_distance
+rotation_chordal_distance = np.rotation_chordal_distance
 
 
 def as_float_array(a):

--- a/numpy_quaternion.c
+++ b/numpy_quaternion.c
@@ -1153,6 +1153,10 @@ BINARY_GEN_UFUNC(floor_divide_scalar, divide_scalar, quaternion, npy_double, qua
 BINARY_GEN_UFUNC(scalar_true_divide, scalar_divide, npy_double, quaternion, quaternion)
 BINARY_GEN_UFUNC(scalar_floor_divide, scalar_divide, npy_double, quaternion, quaternion)
 BINARY_SCALAR_UFUNC(power, quaternion)
+BINARY_UFUNC(rotor_intrinsic_distance, npy_double)
+BINARY_UFUNC(rotor_chordal_distance, npy_double)
+BINARY_UFUNC(rotation_intrinsic_distance, npy_double)
+BINARY_UFUNC(rotation_chordal_distance, npy_double)
 
 
 // Used to create unit rotor from spherical coordinates, this can be
@@ -1181,50 +1185,6 @@ quaternion_from_euler_angles(PyObject *self, PyObject *args )
   }
   Q->obval = quaternion_create_from_euler_angles(alpha, beta, gamma);
   return (PyObject*)Q;
-}
-
-static PyObject*
-pyquaternion_rotor_intrinsic_distance(PyObject *self, PyObject *args)
-{
-  PyObject* Q1 = {0};
-  PyObject* Q2 = {0};
-  if (!PyArg_ParseTuple(args, "OO", &Q1, &Q2)) {
-    return NULL;
-  }
-  return PyFloat_FromDouble(rotor_intrinsic_distance(((PyQuaternion*)Q1)->obval, ((PyQuaternion*)Q2)->obval));
-}
-
-static PyObject*
-pyquaternion_rotor_chordal_distance(PyObject *self, PyObject *args)
-{
-  PyObject* Q1 = {0};
-  PyObject* Q2 = {0};
-  if (!PyArg_ParseTuple(args, "OO", &Q1, &Q2)) {
-    return NULL;
-  }
-  return PyFloat_FromDouble(rotor_chordal_distance(((PyQuaternion*)Q1)->obval, ((PyQuaternion*)Q2)->obval));
-}
-
-static PyObject*
-pyquaternion_rotation_intrinsic_distance(PyObject *self, PyObject *args)
-{
-  PyObject* Q1 = {0};
-  PyObject* Q2 = {0};
-  if (!PyArg_ParseTuple(args, "OO", &Q1, &Q2)) {
-    return NULL;
-  }
-  return PyFloat_FromDouble(rotation_intrinsic_distance(((PyQuaternion*)Q1)->obval, ((PyQuaternion*)Q2)->obval));
-}
-
-static PyObject*
-pyquaternion_rotation_chordal_distance(PyObject *self, PyObject *args)
-{
-  PyObject* Q1 = {0};
-  PyObject* Q2 = {0};
-  if (!PyArg_ParseTuple(args, "OO", &Q1, &Q2)) {
-    return NULL;
-  }
-  return PyFloat_FromDouble(rotation_chordal_distance(((PyQuaternion*)Q1)->obval, ((PyQuaternion*)Q2)->obval));
 }
 
 // Interface to the module-level slerp function
@@ -1348,14 +1308,6 @@ static PyMethodDef QuaternionMethods[] = {
    "Generate unit quaternion from spherical coordinates"},
   {"from_euler_angles", quaternion_from_euler_angles, METH_VARARGS,
    "Generate unit quaternion from Euler angles as `exp(alpha*z/2) * exp(beta*y/2) * exp(gamma*z/2)`"},
-  {"rotor_intrinsic_distance", pyquaternion_rotor_intrinsic_distance, METH_VARARGS,
-   "Distance measure intrinsic to rotor manifold"},
-  {"rotor_chordal_distance", pyquaternion_rotor_chordal_distance, METH_VARARGS,
-   "Distance measure from embedding of rotor manifold"},
-  {"rotation_intrinsic_distance", pyquaternion_rotation_intrinsic_distance, METH_VARARGS,
-   "Distance measure intrinsic to rotation manifold"},
-  {"rotation_chordal_distance", pyquaternion_rotation_chordal_distance, METH_VARARGS,
-   "Distance measure from embedding of rotation manifold"},
   {"slerp_evaluate", pyquaternion_slerp_evaluate, METH_VARARGS,
    "Interpolate linearly along the geodesic between two rotors \n\n"
    "See also `numpy.slerp_vectorized` for a vectorized version of this function, and\n"
@@ -1626,6 +1578,20 @@ PyMODINIT_FUNC initnumpy_quaternion(void) {
   REGISTER_UFUNC_SCALAR(true_divide);
   REGISTER_UFUNC_SCALAR(floor_divide);
   REGISTER_UFUNC_SCALAR(power);
+
+  // quat, quat -> double
+  arg_types[0] = quaternion_descr->type_num;
+  arg_types[1] = quaternion_descr->type_num;
+  arg_types[2] = NPY_DOUBLE;
+  REGISTER_NEW_UFUNC(rotor_intrinsic_distance, 2, 1,
+                     "Distance measure intrinsic to rotor manifold");
+  REGISTER_NEW_UFUNC(rotor_chordal_distance, 2, 1,
+                     "Distance measure from embedding of rotor manifold");
+  REGISTER_NEW_UFUNC(rotation_intrinsic_distance, 2, 1,
+                     "Distance measure intrinsic to rotation manifold");
+  REGISTER_NEW_UFUNC(rotation_chordal_distance, 2, 1,
+                     "Distance measure from embedding of rotation manifold");
+
 
   /* I think before I do the following, I'll have to update numpy_dict
    * somehow, presumably with something related to

--- a/quaternion.h
+++ b/quaternion.h
@@ -442,28 +442,28 @@ extern "C" {
   }
 
   // Associated functions
-  static NPY_INLINE double rotor_intrinsic_distance(quaternion q1, quaternion q2) {
+  static NPY_INLINE double quaternion_rotor_intrinsic_distance(quaternion q1, quaternion q2) {
     return 2*quaternion_absolute(quaternion_log(quaternion_divide(q1,q2)));
   }
-  static NPY_INLINE double rotor_chordal_distance(quaternion q1, quaternion q2) {
+  static NPY_INLINE double quaternion_rotor_chordal_distance(quaternion q1, quaternion q2) {
     return quaternion_absolute(quaternion_subtract(q1,q2));
   }
-  static NPY_INLINE double rotation_intrinsic_distance(quaternion q1, quaternion q2) {
-    if(rotor_chordal_distance(q1,q2)<=1.414213562373096) {
+  static NPY_INLINE double quaternion_rotation_intrinsic_distance(quaternion q1, quaternion q2) {
+    if(quaternion_rotor_chordal_distance(q1,q2)<=1.414213562373096) {
       return 2*quaternion_absolute(quaternion_log(quaternion_divide(q1,q2)));
     } else {
       return 2*quaternion_absolute(quaternion_log(quaternion_divide(q1,quaternion_negative(q2))));
     }
   }
-  static NPY_INLINE double rotation_chordal_distance(quaternion q1, quaternion q2) {
-    if(rotor_chordal_distance(q1,q2)<=1.414213562373096) {
+  static NPY_INLINE double quaternion_rotation_chordal_distance(quaternion q1, quaternion q2) {
+    if(quaternion_rotor_chordal_distance(q1,q2)<=1.414213562373096) {
       return quaternion_absolute(quaternion_subtract(q1,q2));
     } else {
       return quaternion_absolute(quaternion_add(q1,q2));
     }
   }
   static NPY_INLINE quaternion slerp(quaternion q1, quaternion q2, double tau) {
-    if(rotor_chordal_distance(q1,q2)<=1.414213562373096) {
+    if(quaternion_rotor_chordal_distance(q1,q2)<=1.414213562373096) {
       return quaternion_multiply( quaternion_power_scalar(quaternion_divide(q2,q1), tau), q1);
     } else {
       return quaternion_multiply( quaternion_power_scalar(quaternion_divide(quaternion_negative(q2),q1), tau), q1);


### PR DESCRIPTION
Previously, metric functions (`rot[or|ation]_[intrinsic|chordal]_distance`) were implemented as simple `PyObject` routines, with _unsafe_ casts to `PyQuaternion`. That means these functions did not broadcast their arguments, and silently returned bad results when passed anything other than scalar `quaternion`s (even zero-dim `ndarray`s!):

(before)
```python
>>> import quaternion
>>> import numpy as np
>>> np.ones((), dtype=quaternion.quaternion)
array(quaternion(1, 0, 0, 0), dtype=quaternion)
>>> quaternion.rotation_intrinsic_distance(quaternion.one, np.ones((), dtype=quaternion.quaternion))
nan
>>> quaternion.rotor_chordal_distance(5, 6)
0.0
>>> quaternion.rotor_chordal_distance({}, [])
0.0
>>> quaternion.rotor_intrinsic_distance(quaternion.one, quaternion.one[...])
nan
>>> quaternion.rotation_chordal_distance(np.ones(5, dtype=quaternion.quaternion), np.ones(5, dtype=quaternion.quaternion))
nan
```

This patch makes these metric functions ufuncs which broadcast correctly and are type-safe:

(after)
```python
>>> import quaternion
>>> import numpy as np
>>> quaternion.rotation_intrinsic_distance(quaternion.one, np.ones((), dtype=quaternion.quaternion))
0.0
>>> quaternion.rotor_chordal_distance(5, 6)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: ufunc 'rotor_chordal_distance' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
>>> quaternion.rotor_chordal_distance({}, [])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: ufunc 'rotor_chordal_distance' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
>>> quaternion.rotor_intrinsic_distance(quaternion.one, quaternion.one[...])
0.0
>>> quaternion.rotation_chordal_distance(np.ones(5, dtype=quaternion.quaternion), np.ones(5, dtype=quaternion.quaternion))
array([ 0.,  0.,  0.,  0.,  0.])
```

This is accomplished through the following changes in the first commit:
* Metric functions are renamed to start with `quaternion_`, like other ufuncs.
* Ufuncs are declared and registered using existing macros.
* Old `pyquaternion_` functions are removed.
* New ufuncs are copied into the `quaternion` module (note that they appear in `numpy` when registered), so that existing code continues to work.

This change does add some overhead to the scalar calls; it's particularly noticeable in `test_metrics`, which aggressively calls these functions with scalars. I've included a second commit which rewrites the tests into vectorized form; now they are much faster than they were originally. The price is that the tests do not read as transparently.