### PR TITLE
Fix setting an element with a sequence

### DIFF
--- a/numpy_quaternion.c
+++ b/numpy_quaternion.c
@@ -896,28 +896,27 @@ QUATERNION_copyswapn(quaternion *dst, npy_intp dstride,
   Py_DECREF(descr);
 }
 
-static int QUATERNION_setitem(PyObject* item, void* data, void* ap)
+static int QUATERNION_setitem(PyObject* item, quaternion* qp, void* ap)
 {
   PyObject *element;
-  quaternion q = {0};
   if(PyQuaternion_Check(item)) {
-    memcpy(data,&(((PyQuaternion *)item)->obval),sizeof(quaternion));
+    memcpy(qp,&(((PyQuaternion *)item)->obval),sizeof(quaternion));
   } else if(PySequence_Check(item) && PySequence_Length(item)==4) {
     element = PySequence_GetItem(item, 0);
     if(element == NULL) { return -1; } /* Not a sequence, or other failure */
-    q.w = PyFloat_AsDouble(element);
+    qp->w = PyFloat_AsDouble(element);
     Py_DECREF(element);
     element = PySequence_GetItem(item, 1);
     if(element == NULL) { return -1; } /* Not a sequence, or other failure */
-    q.x = PyFloat_AsDouble(element);
+    qp->x = PyFloat_AsDouble(element);
     Py_DECREF(element);
     element = PySequence_GetItem(item, 2);
     if(element == NULL) { return -1; } /* Not a sequence, or other failure */
-    q.y = PyFloat_AsDouble(element);
+    qp->y = PyFloat_AsDouble(element);
     Py_DECREF(element);
     element = PySequence_GetItem(item, 3);
     if(element == NULL) { return -1; } /* Not a sequence, or other failure */
-    q.z = PyFloat_AsDouble(element);
+    qp->z = PyFloat_AsDouble(element);
     Py_DECREF(element);
   } else {
     PyErr_SetString(PyExc_TypeError,

--- a/test/test_quaternion.py
+++ b/test/test_quaternion.py
@@ -1088,7 +1088,7 @@ def test_setitem_quat(Qs):
     # setitem from quaternion
     for j in range(len(Ps)):
         Ps[j] = np.quaternion(1.3, 2.4, 3.5, 4.7)
-        for k in range(j):
+        for k in range(j + 1):
             assert Ps[k] == np.quaternion(1.3, 2.4, 3.5, 4.7)
         for k in range(j + 1, len(Ps)):
             assert Ps[k] == Qs[k]
@@ -1109,7 +1109,7 @@ def test_setitem_quat(Qs):
             Ps[0] = seq_type((1.3, 2.4, 3.5, 4.7, 5.9, np.nan))
         for j in range(len(Ps)):
             Ps[j] = seq_type((1.3, 2.4, 3.5, 4.7))
-            for k in range(j):
+            for k in range(j + 1):
                 assert Ps[k] == np.quaternion(1.3, 2.4, 3.5, 4.7)
             for k in range(j + 1, len(Ps)):
                 assert Ps[k] == Qs[k]

--- a/test/test_quaternion.py
+++ b/test/test_quaternion.py
@@ -1111,8 +1111,8 @@ def test_setitem_quat(Qs):
             Ps[j] = seq_type((1.3, 2.4, 3.5, 4.7))
             for k in range(j):
                 assert Ps[k] == np.quaternion(1.3, 2.4, 3.5, 4.7)
-                for k in range(j + 1, len(Ps)):
-                    assert Ps[k] == Qs[k]
+            for k in range(j + 1, len(Ps)):
+                assert Ps[k] == Qs[k]
     with pytest.raises(TypeError):
         Ps[0] = 's'
     with pytest.raises(TypeError):

--- a/test/test_quaternion.py
+++ b/test/test_quaternion.py
@@ -1084,7 +1084,7 @@ def test_arrfuncs():
 
 
 def test_setitem_quat(Qs):
-    Ps = Qs[:]
+    Ps = Qs.copy()
     # setitem from quaternion
     for j in range(len(Ps)):
         Ps[j] = np.quaternion(1.3, 2.4, 3.5, 4.7)
@@ -1094,7 +1094,7 @@ def test_setitem_quat(Qs):
             assert Ps[k] == Qs[k]
     # setitem from np.array, list, or tuple
     for seq_type in [np.array, list, tuple]:
-        Ps = Qs[:]
+        Ps = Qs.copy()
         with pytest.raises(TypeError):
             Ps[0] = seq_type(())
         with pytest.raises(TypeError):


### PR DESCRIPTION
Since https://github.com/moble/quaternion/commit/49c169163e329ac73ac05b88aee87e451ee415bd, setting an element of a quaternion array with a sequence does not actually work, because data is never copied into the array:

```python
>>> import quaternion
>>> import numpy as np
>>> a = np.zeros(1, quaternion.quaternion)
>>> a[0] = 1, 2, 3, 4
>>> a
array([quaternion(0, 0, 0, 0)], dtype=quaternion)
```

Even though there was a test for this, the test is not correct, because the line
```python
Ps = Qs[:]
```
is used to (apparently) create a copy of `Qs`, though since `Qs` is an `ndarray` it actually creates an alias. As a result the elements of `Ps` are already set by previous tests.

This PR contains four commits:
1. The first fixes an adjacent performance issue in `test_setitem_quat`; there does not seem to be any reason for the `j + 1 ... len(Ps)` loop to be inside the `0 ... j` loop.
2. The second fixes another adjacent issue: the checks omit element `j`.
3. The third fixes the test bug by actually copying `Qs`.
4. The fourth fixes the `setitem` bug by directly modifying the argument. The type change to `QUATERNION_setitem` does not create a problem because it is later assigned with an explicit cast.