### PR TITLE
Cleanup unused module_dict variable

### DIFF
--- a/numpy_quaternion.c
+++ b/numpy_quaternion.c
@@ -1351,7 +1351,6 @@ PyMODINIT_FUNC initnumpy_quaternion(void) {
 #endif
 
   PyObject *module;
-  PyObject *module_dict;
   PyObject *tmp_ufunc;
   PyObject *slerp_evaluate_ufunc;
   PyObject *squad_evaluate_ufunc;
@@ -1371,8 +1370,6 @@ PyMODINIT_FUNC initnumpy_quaternion(void) {
   if(module==NULL) {
     INITERROR;
   }
-
-  module_dict = PyModule_GetDict(module);
 
   // Initialize numpy
   import_array();


### PR DESCRIPTION
Straightforward. As far as I can tell, this completes the work begun in https://github.com/moble/quaternion/commit/95a2f417271700cd120d8f6288962400beeaec98 and (together with #79) eliminates warnings on my system.

Question then for @moble: do you want to default to `-Werror`? I only noticed the issue in #79 due to the warning...