### PR TITLE
Add support for appveyor and pip upload

### DIFF
--- a/.appveyor.cmd
+++ b/.appveyor.cmd
@@ -1,0 +1,90 @@
+:: Taken from https://github.com/ogrisel/python-appveyor-demo
+::
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds, and 64-bit builds for 3.5 and beyond, do not require specific
+:: environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+::
+:: Notes about batch files for Python people:
+::
+:: Quotes in values are literally part of the values:
+::      SET FOO="bar"
+:: FOO is now five characters long: " b a r "
+:: If you don't want quotes, don't include them on the right-hand side.
+::
+:: The CALL lines at the end of this file look redundant, but if you move them
+:: outside of the IF clauses, they do not run properly in the SET_SDK_64==Y
+:: case, I don't know why.
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+SET WIN_WDK=c:\Program Files (x86)\Windows Kits\10\Include\wdf
+
+:: Extract the major and minor versions, and allow for the minor version to be
+:: more than 9.  This requires the version number to have two dots in it.
+SET MAJOR_PYTHON_VERSION=%PYTHON_VERSION:~0,1%
+IF "%PYTHON_VERSION:~3,1%" == "." (
+    SET MINOR_PYTHON_VERSION=%PYTHON_VERSION:~2,1%
+) ELSE (
+    SET MINOR_PYTHON_VERSION=%PYTHON_VERSION:~2,2%
+)
+
+:: Based on the Python version, determine what SDK version to use, and whether
+:: to set the SDK for 64-bit.
+IF %MAJOR_PYTHON_VERSION% == 2 (
+    SET WINDOWS_SDK_VERSION="v7.0"
+    SET SET_SDK_64=Y
+) ELSE (
+    IF %MAJOR_PYTHON_VERSION% == 3 (
+        SET WINDOWS_SDK_VERSION="v7.1"
+        IF %MINOR_PYTHON_VERSION% LEQ 4 (
+            SET SET_SDK_64=Y
+        ) ELSE (
+            SET SET_SDK_64=N
+            IF EXIST "%WIN_WDK%" (
+                :: See: https://connect.microsoft.com/VisualStudio/feedback/details/1610302/
+                REN "%WIN_WDK%" 0wdf
+            )
+        )
+    ) ELSE (
+        ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+        EXIT 1
+    )
+)
+
+IF %PYTHON_ARCH% == 64 (
+    IF %SET_SDK_64% == Y (
+        ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+        SET DISTUTILS_USE_SDK=1
+        SET MSSdk=1
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    ) ELSE (
+        ECHO Using default MSVC build environment for 64 bit architecture
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    )
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,16 +36,15 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
   - ECHO "%cd%"
-  - ps: "ls \"C:/projects/quaternion\""
 
   - "python -m pip install --upgrade pip"
   - "%CMD_IN_ENV% pip install -r requirements.txt"
   - "%CMD_IN_ENV% pip install pytest"
-  - "%CMD_IN_ENV% python setup.py install"
+  # - "%CMD_IN_ENV% python setup.py install"
 
-# build_script:
-#   # Build the compiled extension
-#   - "%CMD_IN_ENV% python setup.py build"
+build_script:
+  # Build the compiled extension
+  - "%CMD_IN_ENV% python setup.py build"
 
 test_script:
   # Run the project tests

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,7 +36,7 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
   - ECHO "%cd%"
-  - ps: "ls %cd%"
+  - ps: "ls \"C:/projects/quaternion\""
 
   - "python -m pip install --upgrade pip"
   - "%CMD_IN_ENV% pip install -r requirements.txt"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,6 +28,9 @@ install:
 
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
+  - git log -1 --format=%%cd --date=format:'%%Y.%%m.%%d.%%H.%%M.%%S'
+  - git log -1 --format=%%cd --date=format:'%%Y.%%-m.%%-d.%%-H.%%-M.%%-S'
+
   # Print some useful information
   # - ECHO "Filesystem root:"
   # - ps: "ls \"C:/\""
@@ -39,29 +42,17 @@ install:
 
   - "python -m pip install --upgrade pip"
   - "%CMD_IN_ENV% pip install -r requirements.txt"
-  - "%CMD_IN_ENV% pip install pytest wheel"
-  # - "%CMD_IN_ENV% python setup.py install"
-
-# build_script:
-#   # Build the compiled extension
-#   - "%CMD_IN_ENV% python setup.py build"
+  - "%CMD_IN_ENV% pip install --upgrade pytest wheel twine"
 
 build_script:
-  # Build the compiled extension
   - "%CMD_IN_ENV% python setup.py install"
-
-# build: off
 
 test_script:
   # Run the project tests
   - "%CMD_IN_ENV% python -m pytest"
 
 after_test:
-  # If tests are successful, create binary packages for the project.
-  - "WHERE wheel.exe"
   - "%CMD_IN_ENV% python setup.py bdist_wheel"
-  - ps: "ls dist"
 
 artifacts:
-  # Archive the generated packages in the ci.appveyor.com build report.
-  - path: dist\*
+  - path: dist\*.whl

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   - git --version
-  - git log -1 --format=%cI
+  - git log -1 --format=%%cI
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%m.%d.%H.%M.%S'\"
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%-m.%-d.%-H.%-M.%-S'\"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,15 +10,15 @@ environment:
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
-    # - PYTHON: "C:\\Python34-x64"
-    #   PYTHON_VERSION: "3.4.x"
-    #   PYTHON_ARCH: "64"
-    # - PYTHON: "C:\\Python35-x64"
-    #   PYTHON_VERSION: "3.5.x"
-    #   PYTHON_ARCH: "64"
-    # - PYTHON: "C:\\Python36-x64"
-    #   PYTHON_VERSION: "3.6.x"
-    #   PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "64"
 
 install:
   - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
@@ -28,10 +28,9 @@ install:
 
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
-  - git log -1 --format=%%%%cI
-  - git log -1 --format=%%%%cd --date=format:'%%%%Y.%%%%m.%%%%d.%%%%H.%%%%M.%%%%S'
 
   # Print some useful information
+  # - git log -1 --format=%%%%cd --date=format:'%%%%Y.%%%%m.%%%%d.%%%%H.%%%%M.%%%%S'
   # - ECHO "Filesystem root:"
   # - ps: "ls \"C:/\""
   # - ECHO "Installed SDKs:"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,6 +28,7 @@ install:
 
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
+  - git --version
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%m.%d.%H.%M.%S'\"
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%-m.%-d.%-H.%-M.%-S'\"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ install:
   - ps: "ls \"C:/projects/quaternion\""
 
   - "python -m pip install --upgrade pip"
-  - "%CMD_IN_ENV% pip install -r .\requirements.txt"
+  - "%CMD_IN_ENV% pip install -r ./requirements.txt"
   - "%CMD_IN_ENV% pip install pytest"
   - "%CMD_IN_ENV% python setup.py install"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,8 +28,8 @@ install:
 
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
-  - git --version
   - git log -1 --format=%%%%cI
+  - git log -1 --format=%%%%cd --date=format:'%%%%Y.%%%%m.%%%%d.%%%%H.%%%%M.%%%%S'
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%m.%d.%H.%M.%S'\"
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%-m.%-d.%-H.%-M.%-S'\"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,9 +35,10 @@ install:
   - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+  - ECHO "%cd%"
 
   - "python -m pip install --upgrade pip"
-  - "%CMD_IN_ENV% pip install -r dev-requirements.txt"
+  - "%CMD_IN_ENV% pip install -r requirements.txt"
   - "%CMD_IN_ENV% pip install pytest"
   - "%CMD_IN_ENV% python setup.py install"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,32 @@
+environment:
+  matrix:
+    # For Python versions available on Appveyor, see
+    # http://www.appveyor.com/docs/installed-software#python
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python34-x64"
+      DISTUTILS_USE_SDK: "1"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
+
+install:
+  - "%PYTHON%\\python.exe -m pip install wheel packaging"
+  - "%PYTHON%\\python.exe -m pip install -r ./requirements.txt"
+  - "%PYTHON%\\python.exe -m pip install numba pytest"
+  - "build.cmd %PYTHON%\\python.exe setup.py install"
+
+build: off
+
+test_script:
+  - "%PYTHON%\\python.exe -m pytest"
+
+after_test:
+  - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
+
+artifacts:
+  # bdist_wheel puts your built wheel in the dist directory
+  - path: dist\*
+
+#on_success:
+#  You can use this step to upload your artifacts to a public website.
+#  See Appveyor's documentation for more details. Or you can simply
+#  access your wheels from the Appveyor "artifacts" tab for your build.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,6 @@ install:
 
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
-
   # Print some useful information
   # - git log -1 --format=%%%%cd --date=format:'%%%%Y.%%%%m.%%%%d.%%%%H.%%%%M.%%%%S'
   - "python --version"
@@ -56,6 +55,5 @@ after_test:
   - "%CMD_IN_ENV% python setup.py bdist_wheel"
 
 on_success:
-  # - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% -r pypi dist/*.whl"
-  - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% --repository-url https://test.pypi.org/legacy/ dist/*.whl"
+  - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% -r pypi dist/*.whl"
  

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,9 +30,6 @@ install:
 
   - git log -1 --format=%%%%cI
   - git log -1 --format=%%%%cd --date=format:'%%%%Y.%%%%m.%%%%d.%%%%H.%%%%M.%%%%S'
-  - git log -1 --format=%%%%cd --date=format:'%%%%Y.%%%%-m.%%%%-d.%%%%-H.%%%%-M.%%%%-S'
-  - git log -1 --format=\"%cd\" --date=\"format:'%Y.%m.%d.%H.%M.%S'\"
-  - git log -1 --format=\"%cd\" --date=\"format:'%Y.%-m.%-d.%-H.%-M.%-S'\"
 
   # Print some useful information
   # - ECHO "Filesystem root:"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   - git --version
-  - git log -1 --format=\"%%cd\" --date=iso
+  - git log -1 --format=\"^%cd\" --date=iso
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%m.%d.%H.%M.%S'\"
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%-m.%-d.%-H.%-M.%-S'\"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   - git --version
-  - git log -1 --format="%cd" --date=iso
+  - git log -1 --format=%cI
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%m.%d.%H.%M.%S'\"
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%-m.%-d.%-H.%-M.%-S'\"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,11 +40,11 @@ install:
   - "python -m pip install --upgrade pip"
   - "%CMD_IN_ENV% pip install -r requirements.txt"
   - "%CMD_IN_ENV% pip install pytest"
-  # - "%CMD_IN_ENV% python setup.py install"
+  - "%CMD_IN_ENV% python setup.py install"
 
-build_script:
-  # Build the compiled extension
-  - "%CMD_IN_ENV% python setup.py build"
+# build_script:
+#   # Build the compiled extension
+#   - "%CMD_IN_ENV% python setup.py build"
 
 test_script:
   # Run the project tests

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,5 +61,5 @@ after_test:
 
 on_success:
   # - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% -r pypi dist\*.whl"
-  - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% --repository-url 'https://test.pypi.org/legacy/' dist\*.whl"
+  - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% --repository-url 'https://test.pypi.org/legacy/' dist/*.whl"
  

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ install:
   - ps: "ls \"C:/projects/quaternion\""
 
   - "python -m pip install --upgrade pip"
-  - "%CMD_IN_ENV% pip install -r requirements.txt"
+  - "%CMD_IN_ENV% pip install -r .\requirements.txt"
   - "%CMD_IN_ENV% pip install pytest"
   - "%CMD_IN_ENV% python setup.py install"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ environment:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
-    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\.appveyor.cmd"
   matrix:
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.x"
@@ -39,7 +39,7 @@ install:
   - ps: "ls \"C:/projects/quaternion\""
 
   - "python -m pip install --upgrade pip"
-  - "%CMD_IN_ENV% pip install -r \"C:/projects/quaternion/requirements.txt\""
+  - "%CMD_IN_ENV% pip install -r requirements.txt"
   - "%CMD_IN_ENV% pip install pytest"
   - "%CMD_IN_ENV% python setup.py install"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,10 +29,10 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   # Print some useful information
-  - ECHO "Filesystem root:"
-  - ps: "ls \"C:/\""
-  - ECHO "Installed SDKs:"
-  - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
+  # - ECHO "Filesystem root:"
+  # - ps: "ls \"C:/\""
+  # - ECHO "Installed SDKs:"
+  # - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
   - ECHO "%cd%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   - git --version
-  - git log -1 --format=\"^%cd\" --date=iso
+  - git log -1 --format="%cd" --date=iso
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%m.%d.%H.%M.%S'\"
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%-m.%-d.%-H.%-M.%-S'\"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -60,6 +60,6 @@ after_test:
 #   - path: dist\*.whl
 
 on_success:
-  # - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% -r pypi dist\*.whl"
-  - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% --repository-url 'https://test.pypi.org/legacy/' dist/*.whl"
+  # - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% -r pypi dist/*.whl"
+  - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% --repository-url https://test.pypi.org/legacy/ dist/*.whl"
  

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,15 +10,15 @@ environment:
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "64"
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "64"
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.x"
-      PYTHON_ARCH: "64"
+    # - PYTHON: "C:\\Python34-x64"
+    #   PYTHON_VERSION: "3.4.x"
+    #   PYTHON_ARCH: "64"
+    # - PYTHON: "C:\\Python35-x64"
+    #   PYTHON_VERSION: "3.5.x"
+    #   PYTHON_ARCH: "64"
+    # - PYTHON: "C:\\Python36-x64"
+    #   PYTHON_VERSION: "3.6.x"
+    #   PYTHON_ARCH: "64"
 
 install:
   - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
@@ -29,6 +29,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   - git --version
+  - git log -1 --format=\"%cd\" --date=iso
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%m.%d.%H.%M.%S'\"
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%-m.%-d.%-H.%-M.%-S'\"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,11 +40,15 @@ install:
   - "python -m pip install --upgrade pip"
   - "%CMD_IN_ENV% pip install -r requirements.txt"
   - "%CMD_IN_ENV% pip install pytest"
-  - "%CMD_IN_ENV% python setup.py install"
+  # - "%CMD_IN_ENV% python setup.py install"
 
 # build_script:
 #   # Build the compiled extension
 #   - "%CMD_IN_ENV% python setup.py build"
+
+build_script:
+  # Build the compiled extension
+  - "%CMD_IN_ENV% python setup.py install"
 
 test_script:
   # Run the project tests

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,6 +23,9 @@ environment:
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
 
+cache:
+  - '%LOCALAPPDATA%\pip\Cache'
+
 install:
   - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
         https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,5 +61,5 @@ after_test:
 
 on_success:
   # - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% -r pypi dist\*.whl"
-  - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% --repository-url https://test.pypi.org/legacy/ dist\*.whl"
+  - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% --repository-url 'https://test.pypi.org/legacy/' dist\*.whl"
  

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ install:
   - ps: "ls \"C:/projects/quaternion\""
 
   - "python -m pip install --upgrade pip"
-  - "%CMD_IN_ENV% pip install -r ./requirements.txt"
+  - "%CMD_IN_ENV% pip install -r \"C:/projects/quaternion/requirements.txt\""
   - "%CMD_IN_ENV% pip install pytest"
   - "%CMD_IN_ENV% python setup.py install"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,8 +28,8 @@ install:
 
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
-  - git log -1 --format=%%cd --date=format:'%%Y.%%m.%%d.%%H.%%M.%%S'
-  - git log -1 --format=%%cd --date=format:'%%Y.%%-m.%%-d.%%-H.%%-M.%%-S'
+  - git log -1 --format=\"%cd\" --date=\"format:'%Y.%m.%d.%H.%M.%S'\"
+  - git log -1 --format=\"%cd\" --date=\"format:'%Y.%-m.%-d.%-H.%-M.%-S'\"
 
   # Print some useful information
   # - ECHO "Filesystem root:"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   - git --version
-  - git log -1 --format=\"%cd\" --date=iso
+  - git log -1 --format=\"%%cd\" --date=iso
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%m.%d.%H.%M.%S'\"
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%-m.%-d.%-H.%-M.%-S'\"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ install:
 
   - "python -m pip install --upgrade pip"
   - "%CMD_IN_ENV% pip install -r requirements.txt"
-  - "%CMD_IN_ENV% pip install pytest"
+  - "%CMD_IN_ENV% pip install pytest wheel"
   # - "%CMD_IN_ENV% python setup.py install"
 
 # build_script:
@@ -50,53 +50,18 @@ build_script:
   # Build the compiled extension
   - "%CMD_IN_ENV% python setup.py install"
 
+# build: off
+
 test_script:
   # Run the project tests
   - "%CMD_IN_ENV% python -m pytest"
 
 after_test:
   # If tests are successful, create binary packages for the project.
-  - "%CMD_IN_ENV% pip install wheel"
+  - "WHERE wheel.exe"
   - "%CMD_IN_ENV% python setup.py bdist_wheel"
   - ps: "ls dist"
 
 artifacts:
   # Archive the generated packages in the ci.appveyor.com build report.
   - path: dist\*
-
-
-
-
-
-# environment:
-#   matrix:
-#     # For Python versions available on Appveyor, see
-#     # http://www.appveyor.com/docs/installed-software#python
-#     - PYTHON: "C:\\Python27-x64"
-#       DISTUTILS_USE_SDK: "1"
-#     - PYTHON: "C:\\Python35-x64"
-#     - PYTHON: "C:\\Python36-x64"
-
-# install:
-#   - "%PYTHON%\\python.exe -m pip install --upgrade pip"
-#   - "%PYTHON%\\python.exe -m pip install -r ./requirements.txt"
-#   - "%PYTHON%\\python.exe -m pip install pytest"
-#   - "%PYTHON%\\python.exe setup.py install"
-
-# build: off
-
-# test_script:
-#   - "%PYTHON%\\python.exe -m pytest"
-
-# after_test:
-#   - "%PYTHON%\\python.exe -m pip install wheel"
-#   - "%PYTHON%\\python.exe setup.py bdist_wheel"
-
-# artifacts:
-#   # bdist_wheel puts your built wheel in the dist directory
-#   - path: dist\*
-
-# #on_success:
-# #  You can use this step to upload your artifacts to a public website.
-# #  See Appveyor's documentation for more details. Or you can simply
-# #  access your wheels from the Appveyor "artifacts" tab for your build.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,10 +37,6 @@ install:
 
   # Print some useful information
   # - git log -1 --format=%%%%cd --date=format:'%%%%Y.%%%%m.%%%%d.%%%%H.%%%%M.%%%%S'
-  # - ECHO "Filesystem root:"
-  # - ps: "ls \"C:/\""
-  # - ECHO "Installed SDKs:"
-  # - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
   - ECHO "%cd%"
@@ -58,9 +54,6 @@ test_script:
 
 after_test:
   - "%CMD_IN_ENV% python setup.py bdist_wheel"
-
-# artifacts:
-#   - path: dist\*.whl
 
 on_success:
   # - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% -r pypi dist/*.whl"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,16 +3,16 @@ environment:
     # For Python versions available on Appveyor, see
     # http://www.appveyor.com/docs/installed-software#python
     - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python34-x64"
-      DISTUTILS_USE_SDK: "1"
+    # - PYTHON: "C:\\Python34-x64"
+    #   DISTUTILS_USE_SDK: "1"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
 
 install:
   - "%PYTHON%\\python.exe -m pip install wheel packaging"
   - "%PYTHON%\\python.exe -m pip install -r ./requirements.txt"
-  - "%PYTHON%\\python.exe -m pip install numba pytest"
-  - "build.cmd %PYTHON%\\python.exe setup.py install"
+  - "%PYTHON%\\python.exe -m pip install pytest"
+  - "%PYTHON%\\python.exe setup.py install"
 
 build: off
 
@@ -20,7 +20,7 @@ test_script:
   - "%PYTHON%\\python.exe -m pytest"
 
 after_test:
-  - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
+  - "%PYTHON%\\python.exe setup.py bdist_wheel"
 
 artifacts:
   # bdist_wheel puts your built wheel in the dist directory

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   - git --version
-  - git log -1 --format=%%cI
+  - git log -1 --format=%%%%cI
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%m.%d.%H.%M.%S'\"
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%-m.%-d.%-H.%-M.%-S'\"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,6 +36,7 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
   - ECHO "%cd%"
+  - ps: "ls %cd%"
 
   - "python -m pip install --upgrade pip"
   - "%CMD_IN_ENV% pip install -r requirements.txt"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,6 +30,7 @@ install:
 
   - git log -1 --format=%%%%cI
   - git log -1 --format=%%%%cd --date=format:'%%%%Y.%%%%m.%%%%d.%%%%H.%%%%M.%%%%S'
+  - git log -1 --format=%%%%cd --date=format:'%%%%Y.%%%%-m.%%%%-d.%%%%-H.%%%%-M.%%%%-S'
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%m.%d.%H.%M.%S'\"
   - git log -1 --format=\"%cd\" --date=\"format:'%Y.%-m.%-d.%-H.%-M.%-S'\"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,32 +1,97 @@
+# Inspired by https://github.com/ogrisel/python-appveyor-demo/blob/master/appveyor.yml
+
 environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
   matrix:
-    # For Python versions available on Appveyor, see
-    # http://www.appveyor.com/docs/installed-software#python
     - PYTHON: "C:\\Python27-x64"
-      DISTUTILS_USE_SDK: "1"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "64"
     - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_ARCH: "64"
     - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "64"
 
 install:
-  - "%PYTHON%\\python.exe -m pip install --upgrade pip"
-  - "%PYTHON%\\python.exe -m pip install -r ./requirements.txt"
-  - "%PYTHON%\\python.exe -m pip install pytest"
-  - "%PYTHON%\\python.exe setup.py install"
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+          throw "There are newer queued builds for this pull request, failing early." }
 
-build: off
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  # Print some useful information
+  - ECHO "Filesystem root:"
+  - ps: "ls \"C:/\""
+  - ECHO "Installed SDKs:"
+  - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  - "python -m pip install --upgrade pip"
+  - "%CMD_IN_ENV% pip install -r dev-requirements.txt"
+  - "%CMD_IN_ENV% pip install pytest"
+  - "%CMD_IN_ENV% python setup.py install"
+
+# build_script:
+#   # Build the compiled extension
+#   - "%CMD_IN_ENV% python setup.py build"
 
 test_script:
-  - "%PYTHON%\\python.exe -m pytest"
+  # Run the project tests
+  - "%CMD_IN_ENV% python -m pytest"
 
 after_test:
-  - "%PYTHON%\\python.exe -m pip install wheel"
-  - "%PYTHON%\\python.exe setup.py bdist_wheel"
+  # If tests are successful, create binary packages for the project.
+  - "%CMD_IN_ENV% pip install wheel"
+  - "%CMD_IN_ENV% python setup.py bdist_wheel"
+  - ps: "ls dist"
 
 artifacts:
-  # bdist_wheel puts your built wheel in the dist directory
+  # Archive the generated packages in the ci.appveyor.com build report.
   - path: dist\*
 
-#on_success:
-#  You can use this step to upload your artifacts to a public website.
-#  See Appveyor's documentation for more details. Or you can simply
-#  access your wheels from the Appveyor "artifacts" tab for your build.
+
+
+
+
+# environment:
+#   matrix:
+#     # For Python versions available on Appveyor, see
+#     # http://www.appveyor.com/docs/installed-software#python
+#     - PYTHON: "C:\\Python27-x64"
+#       DISTUTILS_USE_SDK: "1"
+#     - PYTHON: "C:\\Python35-x64"
+#     - PYTHON: "C:\\Python36-x64"
+
+# install:
+#   - "%PYTHON%\\python.exe -m pip install --upgrade pip"
+#   - "%PYTHON%\\python.exe -m pip install -r ./requirements.txt"
+#   - "%PYTHON%\\python.exe -m pip install pytest"
+#   - "%PYTHON%\\python.exe setup.py install"
+
+# build: off
+
+# test_script:
+#   - "%PYTHON%\\python.exe -m pytest"
+
+# after_test:
+#   - "%PYTHON%\\python.exe -m pip install wheel"
+#   - "%PYTHON%\\python.exe setup.py bdist_wheel"
+
+# artifacts:
+#   # bdist_wheel puts your built wheel in the dist directory
+#   - path: dist\*
+
+# #on_success:
+# #  You can use this step to upload your artifacts to a public website.
+# #  See Appveyor's documentation for more details. Or you can simply
+# #  access your wheels from the Appveyor "artifacts" tab for your build.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,13 +3,12 @@ environment:
     # For Python versions available on Appveyor, see
     # http://www.appveyor.com/docs/installed-software#python
     - PYTHON: "C:\\Python27-x64"
-    # - PYTHON: "C:\\Python34-x64"
-    #   DISTUTILS_USE_SDK: "1"
+      DISTUTILS_USE_SDK: "1"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
 
 install:
-  - "%PYTHON%\\python.exe -m pip install wheel packaging"
+  - "%PYTHON%\\python.exe -m pip install --upgrade pip"
   - "%PYTHON%\\python.exe -m pip install -r ./requirements.txt"
   - "%PYTHON%\\python.exe -m pip install pytest"
   - "%PYTHON%\\python.exe setup.py install"
@@ -20,6 +19,7 @@ test_script:
   - "%PYTHON%\\python.exe -m pytest"
 
 after_test:
+  - "%PYTHON%\\python.exe -m pip install wheel"
   - "%PYTHON%\\python.exe setup.py bdist_wheel"
 
 artifacts:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,9 @@
 # Inspired by https://github.com/ogrisel/python-appveyor-demo/blob/master/appveyor.yml
 
 environment:
+  PYPI_USERNAME: moboyle79
+  PYPI_PASSWORD:
+    secure: Vc+3ztSsC7+3misIum2YKKNMst4c10UkG6Kkq0xr3bg=
   global:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
@@ -53,5 +56,10 @@ test_script:
 after_test:
   - "%CMD_IN_ENV% python setup.py bdist_wheel"
 
-artifacts:
-  - path: dist\*.whl
+# artifacts:
+#   - path: dist\*.whl
+
+on_success:
+  # - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% -r pypi dist\*.whl"
+  - "twine upload -u %PYPI_USERNAME% -p %PYPI_PASSWORD% --repository-url https://test.pypi.org/legacy/ dist\*.whl"
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,17 @@ matrix:
     - os: linux
       python: '3.6'
 
-branches:
-  only:
-    - master
+# branches:
+#   only:
+#     - master
+#     - appveyor
 
 before_install:
   -  lsb_release -a
 
 install:
-  - pip install packaging scipy numba
+  - pip install --upgrade pip
+  - pip install --upgrade packaging scipy numba setuptools
   - git checkout "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
   - git reset --hard "${TRAVIS_COMMIT}"
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,9 @@ matrix:
     - os: linux
       python: '3.6'
 
-# branches:
-#   only:
-#     - master
-#     - appveyor
+branches:
+  except:
+    - appveyor
 
 before_install:
   -  lsb_release -a

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ else:
         on_windows = ('win' in platform.lower() and not 'darwin' in platform.lower())
         if on_windows:
             version = check_output("""git log -1 --format=%cd --date=format:'%Y.%m.%d.%H.%M.%S'""", shell=False)
-            version = version.decode('ascii').rstrip().replace('.0', '.')
+            version = version.decode('ascii').strip().replace('.0', '.').replace("'", "")
         else:
             version = check_output("""git log -1 --format=%cd --date=format:'%Y.%-m.%-d.%-H.%-M.%-S'""", shell=True).decode('ascii').rstrip()
         print("Setup.py using git log version='{0}'".format(version))

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
         depends=['quaternion.c', 'quaternion.h', 'numpy_quaternion.c'],
         include_dirs=[numpy.get_include()]
     )
-    setup(name='quaternion',
+    setup(name='numpy-',
           packages=['quaternion'],
           package_dir={'quaternion': ''},
           ext_modules=[extension],

--- a/setup.py
+++ b/setup.py
@@ -55,14 +55,14 @@ if __name__ == "__main__":
     if numpy.__dict__.get('quaternion') is not None:
         raise DistutilsError('The target NumPy already has a quaternion type')
     extension = Extension(
-        name='quaternion.numpy_quaternion',
+        name='quaternion.numpy_quaternion',  # This is the name of the object file that will be compiled
         sources=['quaternion.c', 'numpy_quaternion.c'],
         extra_compile_args=['-O3'],
         depends=['quaternion.c', 'quaternion.h', 'numpy_quaternion.c'],
         include_dirs=[numpy.get_include()]
     )
-    setup(name='numpy-quaternion',
-          packages=['quaternion'],
+    setup(name='numpy-quaternion',  # Uploaded to pypi under this name
+          packages=['quaternion'],  # This is the actual package name
           package_dir={'quaternion': ''},
           ext_modules=[extension],
           version=version,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ else:
             try:
                 version = strftime("%Y.%-m.%-d.%-H.%-M.%-S", gmtime())
             except ValueError:  # because Windows
-                version = strftime("%Y.%m.%d.%H.%M.%S", gmtime())
+                version = strftime("%Y.%m.%d.%H.%M.%S", gmtime()).replace('.0', '.')
             print("Setup.py using strftime version='{0}'".format(version))
         except:
             version = '0.0.0'

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,8 @@ else:
         from subprocess import check_output
         on_windows = ('win' in platform.lower() and not 'darwin' in platform.lower())
         if on_windows:
-            print('Trying git log on windows...')
             version = check_output("""git log -1 --format=%cd --date=format:'%Y.%m.%d.%H.%M.%S'""", shell=False)
             version = version.decode('ascii').rstrip().replace('.0', '.')
-            print('Got git log on windows...')
         else:
             version = check_output("""git log -1 --format=%cd --date=format:'%Y.%-m.%-d.%-H.%-M.%-S'""", shell=True).decode('ascii').rstrip()
         print("Setup.py using git log version='{0}'".format(version))

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,13 @@ else:
         from sys import platform
         from subprocess import check_output
         on_windows = ('win' in platform.lower() and not 'darwin' in platform.lower())
-        use_shell = not on_windows
-        version = check_output("""git log -1 --format=%cd --date=format:'%Y.%-m.%-d.%-H.%-M.%-S'""", shell=use_shell).decode('ascii').rstrip()
+        if on_windows:
+            print('Trying git log on windows...')
+            version = check_output("""git log -1 --format=%cd --date=format:'%Y.%m.%d.%H.%M.%S'""", shell=False)
+            version = version.decode('ascii').rstrip().replace('.0', '.')
+            print('Got git log on windows...')
+        else:
+            version = check_output("""git log -1 --format=%cd --date=format:'%Y.%-m.%-d.%-H.%-M.%-S'""", shell=True).decode('ascii').rstrip()
         print("Setup.py using git log version='{0}'".format(version))
     except:
         # For cases where this isn't being installed from git.  This gives the wrong version number,

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
         depends=['quaternion.c', 'quaternion.h', 'numpy_quaternion.c'],
         include_dirs=[numpy.get_include()]
     )
-    setup(name='numpy-',
+    setup(name='numpy-quaternion',
           packages=['quaternion'],
           package_dir={'quaternion': ''},
           ext_modules=[extension],

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,8 @@ and Euler-angle representations of rotations.  The core of the code is written i
 
 if __name__ == "__main__":
     from os import getenv
-    from numpy.distutils.core import setup
+    from setuptools import setup
+    # from numpy.distutils.core import setup
     setup(name='numpy-',
           configuration=configuration,
           version=version,

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ and Euler-angle representations of rotations.  The core of the code is written i
 
 if __name__ == "__main__":
     import numpy
-    from distutils.core import setup, Extension
+    from setuptools import setup, Extension
+    # from distutils.core import setup, Extension
     from distutils.errors import DistutilsError
     if numpy.__dict__.get('quaternion') is not None:
         raise DistutilsError('The target NumPy already has a quaternion type')

--- a/setup.py
+++ b/setup.py
@@ -35,21 +35,6 @@ with open('_version.py', 'w') as f:
     f.write('__version__ = "{0}"'.format(version))
 
 
-def configuration(parent_package='', top_path=None):
-    import numpy
-    from distutils.errors import DistutilsError
-    if numpy.__dict__.get('quaternion') is not None:
-        raise DistutilsError('The target NumPy already has a quaternion type')
-    from numpy.distutils.misc_util import Configuration
-    compile_args = ['-O3']
-    config = Configuration('quaternion', parent_package, top_path)
-    config.add_extension('numpy_quaternion',
-                         ['quaternion.c', 'numpy_quaternion.c'],
-                         depends=['quaternion.c', 'quaternion.h', 'numpy_quaternion.c'],
-                         extra_compile_args=compile_args, )
-    return config
-
-
 long_description = """\
 This package creates a quaternion type in python, and further enables numpy to create and manipulate arrays of
 quaternions.  The usual algebraic operations (addition and multiplication) are available, along with numerous
@@ -60,11 +45,22 @@ and Euler-angle representations of rotations.  The core of the code is written i
 
 
 if __name__ == "__main__":
-    from os import getenv
-    from setuptools import setup
-    # from numpy.distutils.core import setup
-    setup(name='numpy-',
-          configuration=configuration,
+    import numpy
+    from distutils.core import setup, Extension
+    from distutils.errors import DistutilsError
+    if numpy.__dict__.get('quaternion') is not None:
+        raise DistutilsError('The target NumPy already has a quaternion type')
+    extension = Extension(
+        name='quaternion.numpy_quaternion',
+        sources=['quaternion.c', 'numpy_quaternion.c'],
+        extra_compile_args=['-O3'],
+        depends=['quaternion.c', 'quaternion.h', 'numpy_quaternion.c'],
+        include_dirs=[numpy.get_include()]
+    )
+    setup(name='quaternion',
+          packages=['quaternion'],
+          package_dir={'quaternion': ''},
+          ext_modules=[extension],
           version=version,
           url='https://github.com/moble/quaternion',
           author='Michael Boyle',


### PR DESCRIPTION
This PR adds two files for appveyor and changes how the setup.py script works.  The appveyor scripts build the module, test it, and — if successful — upload the windows wheels to pypi.  Numerous changes were needed in the setup.py file to get this to work.  The git formatting string was updated to actually work on Windows.  The previous reliance on numpy.distutils has been removed; the script now uses setuptools (which was required to get wheels building on windows for some reason).