### PR TITLE
fix bug in mean_rotor_in_chordal_metric

### DIFF
--- a/calculus.py
+++ b/calculus.py
@@ -319,6 +319,5 @@ def indefinite_integral(f, t):
 @jit
 def definite_integral(f, t):
     Sfdt = np.zeros_like(f)
-    for i in xrange(1, f.shape[0]):
-        Sfdt[i, ...] += (f[i, ...] + f[i - 1, ...]) * ((t[i] - t[i - 1]) / 2.0)
+    Sfdt[1:, ...] = (f[1:, ...] + f[:-1, ...]) * ((t[1:] - t[:-1]) / 2.0)
     return Sfdt

--- a/calculus.py
+++ b/calculus.py
@@ -320,4 +320,4 @@ def indefinite_integral(f, t):
 def definite_integral(f, t):
     Sfdt = np.zeros_like(f)
     Sfdt[1:, ...] = (f[1:, ...] + f[:-1, ...]) * ((t[1:] - t[:-1]) / 2.0)
-    return Sfdt
+    return np.sum(Sfdt)

--- a/means.py
+++ b/means.py
@@ -6,6 +6,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 
 from .calculus import definite_integral
+from . import as_float_array
 
 
 def mean_rotor_in_chordal_metric(R, t=None):
@@ -22,12 +23,10 @@ def mean_rotor_in_chordal_metric(R, t=None):
     faster).
 
     """
-    R_as_array = np.asarray(R, dtype=np.quaternion).view((np.double, 4))
-    if t is not None:
-        return np.quaternion(*sum(R_as_array)).normalized()
-    mean = np.empty((4,), dtype=float)
-    definite_integral(R_as_array, t, mean)
-    return np.quaternion(*mean).normalized()
+    if t is None:
+        return np.sum(R).normalized()
+    mean = definite_integral(R, t)
+    return np.sum(mean).normalized()
 
 
 def optimal_alignment_in_chordal_metric(Ra, Rb, t=None):

--- a/means.py
+++ b/means.py
@@ -22,10 +22,11 @@ def mean_rotor_in_chordal_metric(R, t=None):
     faster).
 
     """
-    if not t:
-        return np.quaternion(*(np.sum(as_float_array(R)))).normalized()
+    R_as_array = np.asarray(R, dtype=np.quaternion).view((np.double, 4))
+    if t is not None:
+        return np.quaternion(*sum(R_as_array)).normalized()
     mean = np.empty((4,), dtype=float)
-    definite_integral(as_float_array(R), t, mean)
+    definite_integral(R_as_array, t, mean)
     return np.quaternion(*mean).normalized()
 
 

--- a/means.py
+++ b/means.py
@@ -26,7 +26,7 @@ def mean_rotor_in_chordal_metric(R, t=None):
     if t is None:
         return np.sum(R).normalized()
     mean = definite_integral(R, t)
-    return np.sum(mean).normalized()
+    return mean.normalized()
 
 
 def optimal_alignment_in_chordal_metric(Ra, Rb, t=None):


### PR DESCRIPTION
Addresses two problems:
1. `sum` returns an array whereas `np.sum` didn't
2. `as_float_array` wasn't defined

This is needed for extrapolation to work in [scri](https://github.com/moble/scri)