### PR TITLE
Qualify quaternion type name by module.

### DIFF
--- a/numpy_quaternion.c
+++ b/numpy_quaternion.c
@@ -810,7 +810,7 @@ static PyTypeObject PyQuaternion_Type = {
   PyObject_HEAD_INIT(NULL)
   0,                                          // ob_size
 #endif
-  "quaternion",                               // tp_name
+  "quaternion.quaternion",                    // tp_name
   sizeof(PyQuaternion),                       // tp_basicsize
   0,                                          // tp_itemsize
   0,                                          // tp_dealloc

--- a/test/test_quaternion.py
+++ b/test/test_quaternion.py
@@ -1364,6 +1364,12 @@ def test_numpy_save_and_load():
     assert np.array_equal(a, b)
 
 
+def test_pickle():
+    import pickle
+    a = quaternion.one
+    assert pickle.loads(pickle.dumps(a)) == a
+
+
 if __name__ == '__main__':
     print("The tests should be run automatically via pytest (`pip install pytest` and then just `pytest`)")
 


### PR DESCRIPTION
The lack of qualifier was defeating pickle (fixes #64).