### PR TITLE
revert definite_integral in mean_rotor_in_chordal_metric

### DIFF
--- a/means.py
+++ b/means.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
-from .calculus import definite_integral
+from .calculus import fd_definite_integral
 
 
 def mean_rotor_in_chordal_metric(R, t=None):
@@ -24,7 +24,7 @@ def mean_rotor_in_chordal_metric(R, t=None):
     """
     if t is None:
         return np.sum(R).normalized()
-    mean = definite_integral(R, t)
+    mean = fd_definite_integral(R, t)
     return mean.normalized()
 
 


### PR DESCRIPTION
`fd_definite_integral` used to be called `definite_integral` and this is what was used in `mean_rotor_in_chodal_metric`. At some point, `definte_integral` changed to a spline implementation which no longer works. This break the ability to make "difference waveforms" and "difference plots" in scri extrapolation.

If the spline implementation of `definite_integral` is used, then follow error gets thrown:
```
...
File "/home/dante/Documents/packages/miniconda3/lib/python3.6/site-packages/quaternion/calculus.py", line 417, in spline
    return InterpolatedUnivariateSpline(t[axis_slice], f[axis_slice], k=spline_degree)
ValueError: No cast function available
```