### PR TITLE
Fix IS_PY3 in numba_wrapper.

### DIFF
--- a/numba_wrapper.py
+++ b/numba_wrapper.py
@@ -2,18 +2,16 @@
 # See LICENSE file for details: <https://github.com/moble/quaternion/blob/master/LICENSE>
 
 from __future__ import division, print_function, absolute_import
+import sys
+
+IS_PY3 = (sys.version_info[:2] >= (3, 0))
 
 ## Allow the code to function without numba, but discourage it
 try:
     from numba import njit, jit, vectorize, int64, float64, complex128
-    try:
-        from numba.utils import IS_PY3
-    except ModuleNotFoundError:
-        IS_PY3 = (sys.version_info[:2] >= (3, 0))
     GOT_NUMBA = True
 except ImportError:
     import warnings
-    import sys
     warning_text = \
         "\n\n" + "!" * 53 + "\n" + \
         "Could not import from numba, which means that some\n" + \
@@ -31,7 +29,6 @@ except ImportError:
     int64 = int
     float64 = float
     complex128 = complex
-    IS_PY3 = (sys.version_info[:2] >= (3, 0))
     GOT_NUMBA = False
 
 if IS_PY3:


### PR DESCRIPTION
The previous fix for the deprecated IS_PY3 import (see #133) had the wrong exception class (`ModuleNotFoundError` rather than `ImportError`). This meant the exception fell through to the next except block and the package thought Numba wasn't installed.

If the exception class is changed then Numba's DeprecationWarning is printed to screen, which is a bit misleading for the user.

This pull request removes the import of IS_PY3 altogether and just uses the fallback version, which is identical to what older versions of Numba used to calculate the value anyway (see [utils.py](https://github.com/numba/numba/blob/0.44.0/numba/utils.py#L27) and [config.py](https://github.com/numba/numba/blob/0.44.0/numba/config.py#L25) from Numba 0.44.0 for example).