### PR TITLE
Include tests in source distribution. (#146) [skip ci]

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md LICENSE
 include src/numpy_quaternion.c src/quaternion.c src/quaternion.h src/math_msvc_compatibility.h
+recursive-include tests *


### PR DESCRIPTION
When building from a source distribution (e.g., when creating a system package) it is preferable to run the tests on the built code. This requires the tests to be included in the source distribution.

This pull request enables this by adding the tests directory to MANIFEST.in. Note that previous source distributions included the tests; I guess the recent tooling changes dropped it.