### PR TITLE
Vectorized rotation without all possible combinations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import numpy as np
 
 
 # Set this first for easier replacement
-version = "2020.11.2.17.0.49"
+version = "2021.2.5.19.30.10"
 
 if "win" in platform.lower() and not "darwin" in platform.lower():
     extra_compile_args = ["/O2"]

--- a/tests/test_quaternion.py
+++ b/tests/test_quaternion.py
@@ -388,6 +388,50 @@ def test_rotate_vectors(Rs):
     assert quats.shape + vecs.shape == vecsprime.shape, ("Out of shape!", quats.shape, vecs.shape, vecsprime.shape)
 
 
+def test_rotate_vectors_each(Rs):
+    np.random.seed(1234)
+    # Test (1)*(1)
+    vecs = np.random.rand(3)
+    quats = quaternion.z
+    vecsprime = quaternion.rotate_vectors_each(quats, vecs)
+    assert np.allclose(vecsprime,
+                       (quats * quaternion.quaternion(*vecs) * quats.inverse()).vec,
+                       rtol=0.0, atol=0.0)
+    assert vecs.shape == vecsprime.shape, ("Out of shape!", quats.shape, vecs.shape, vecsprime.shape)
+    # Test (N)
+    vecs = np.random.rand(Rs.shape[0], 3)
+    vecsprime = quaternion.rotate_vectors_each(Rs, vecs)
+    for i, vec in enumerate(vecs):
+        assert np.allclose(vecsprime[i],
+                           (Rs[i] * quaternion.quaternion(*vec) * Rs[i].inverse()).vec,
+                           rtol=1e-15, atol=1e-15)
+    assert vecs.shape == vecsprime.shape, ("Out of shape!", quats.shape, vecs.shape, vecsprime.shape)
+    # Test (1)*(N)
+    vecs = np.random.rand(1, Rs.shape[0], 3)
+    vecsprime = quaternion.rotate_vectors_each(Rs.reshape(1, -1), vecs, axis=-1)
+    for i, vec in enumerate(vecs[0, ...]):
+        assert np.allclose(vecsprime[0, i, :],
+                           (Rs[i] * quaternion.quaternion(*vec) * Rs[i].inverse()).vec,
+                           rtol=1e-15, atol=1e-15)
+    assert vecs.shape == vecsprime.shape, ("Out of shape!", quats.shape, vecs.shape, vecsprime.shape)
+    # Test (N)*(1)
+    vecs = np.random.rand(Rs.shape[0], 1, 3)
+    vecsprime = quaternion.rotate_vectors_each(Rs.reshape(-1, 1), vecs, axis=-1)
+    for i, vec in enumerate(vecs[:, 0, :]):
+        assert np.allclose(vecsprime[i, 0, :],
+                           (Rs[i] * quaternion.quaternion(*vec) * Rs[i].inverse()).vec,
+                           rtol=1e-15, atol=1e-15)
+    assert vecs.shape == vecsprime.shape, ("Out of shape!", quats.shape, vecs.shape, vecsprime.shape)
+    # Test (N)*(1) inner axis
+    vecs = np.random.rand(3, Rs.shape[0], 1)
+    vecsprime = quaternion.rotate_vectors_each(Rs.reshape(-1, 1), vecs, axis=0)
+    for i, vec in enumerate(vecs[..., 0].T):
+        assert np.allclose(vecsprime[:, i, 0],
+                           (Rs[i] * quaternion.quaternion(*vec) * Rs[i].inverse()).vec,
+                           rtol=1e-15, atol=1e-15)
+    assert vecs.shape == vecsprime.shape, ("Out of shape!", quats.shape, vecs.shape, vecsprime.shape)
+
+
 def test_allclose(Qs):
     for q in Qs[Qs_nonnan]:
         assert quaternion.allclose(q, q, rtol=0.0, atol=0.0)


### PR DESCRIPTION
In some project I need to rotate some vectors with an array of quaternions, but the implemented `rotate_vectors` is doing much more than I want. More precisely, it is rotating every vector with all quaternions available, so all possible combinations are calculated. I instead want to rotate each vector only with its corresponding quaternion. 

So in the most easy case, for `vecs.shape = (N, 3)` and `quats.shape = (N,)`, I want 
`[rotate_vectors(quats[0], vecs[0, :]), rotate_vectors(quats[1], vecs[1, :]), ... ,rotate_vectors(quats[N-1], vecs[N-1, :])]`.

In more complex cases, it is implement in such a way, that corresponding pairs of quaternion and vector have to be at the same position in both matrices (e.g. for `vecs.shape = (N, M, 3)` and `quats.shape = (N, M)`, the resulting matrix will be of shape `vecs.shape = (N, M, 3)` and each `vecs[n, m, 3]` is rotated by `quats[n, m]`). The axis where the vector dimension is located is still available as an optional argument.

I was not sure what a good explanatory name for this is, so the chosen one can probably be improved.

Is it a desired feature to be worth to include in master? Can I change anything to make it easier for you to merge if it is of any interest?