### PR TITLE
Removed symbols to make compatible with Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import numpy as np
 
 
 # Set this first for easier replacement
-version = "2021.10.7.23.40.37"
+version = "2021.11.4.10.49.38"
 
 if "win" in platform.lower() and not "darwin" in platform.lower():
     extra_compile_args = ["/O2"]

--- a/src/quaternion/__init__.py
+++ b/src/quaternion/__init__.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2021, Michael Boyle
 # See LICENSE file for details: <https://github.com/moble/quaternion/blob/main/LICENSE>
 
-__version__ = "2021.10.7.23.40.37"
+__version__ = "2021.11.4.10.49.38"
 __doc_title__ = "Quaternion dtype for NumPy"
 __doc__ = "Adds a quaternion dtype to NumPy."
 __all__ = ['quaternion',

--- a/src/quaternion/means.py
+++ b/src/quaternion/means.py
@@ -75,8 +75,8 @@ def optimal_alignment_in_chordal_metric(Ra, Rb, t=None):
     return mean_rotor_in_chordal_metric(Ra / Rb, t)
 
 
-def optimal_alignment_in_Euclidean_metric(a⃗, b⃗, t=None):
-    """Return rotor R such that R*b⃗*R̄ is as close to a⃗ as possible
+def optimal_alignment_in_Euclidean_metric(a_v, b_v, t=None):
+    """Return rotor R such that R*b_v*R̄ is as close to a_v as possible
 
     As in the `optimal_alignment_in_chordal_metric` function, the `t` argument is
     optional.  If it is present, the times are used to weight the corresponding
@@ -97,27 +97,29 @@ def optimal_alignment_in_Euclidean_metric(a⃗, b⃗, t=None):
     from scipy.interpolate import InterpolatedUnivariateSpline as spline
     from . import quaternion
 
-    a⃗ = np.asarray(a⃗, dtype=float)
-    b⃗ = np.asarray(b⃗, dtype=float)
-    if a⃗.shape != b⃗.shape:
-        raise ValueError(f"Input vectors must have same shape; a⃗.shape={a⃗.shape}, b⃗.shape={b⃗.shape}")
-    if a⃗.shape[-1] != 3:
-        raise ValueError(f"Final dimension of a⃗ and b⃗ must have size 3; it is {a⃗.shape[-1]}")
-    if t is not None:
-        if a⃗.ndim != 2:
-            raise ValueError(f"If t is not None, a⃗ and b⃗ must have exactly 2 dimensions; they have {a⃗.ndim}")
-        t = np.asarray(t, dtype=float)
-        if a⃗.shape[0] != len(t):
-            raise ValueError(f"Input time must have same length as first dimension of vectors; len(t)={len(t)}")
+    a_v = np.asarray(a_v, dtype=float)
+    b_v = np.asarray(b_v, dtype=float)
+    if a_v.shape != b_v.shape:
+        #raise ValueError(f'Input vectors must have same shape; a_v.shape={a_v.shape}, b_v.shape={b_v.shape}')
+        raise ValueError('Input vectors must have same shape; a_v.shape={!r}, b_v.shape={!r}'.format(a_v.shape, b_v.shape))
 
-    # This constructs the matrix given by Eq. (5.11) of Markley and Crassidis
+    if a_v.shape[-1] != 3:
+        raise ValueError('Final dimension of a_v and b_v must have size 3; it is {!r}'.format(a_v.shape[-1]))
+    if t is not None:
+        if a_v.ndim != 2:
+            raise ValueError('If t is not None, a_v and b_v must have exactly 2 dimensions; they have {!r}'.format(a_v.ndim))
+        t = np.asarray(t, dtype=float)
+        if a_v.shape[0] != len(t):
+            raise ValueError('Input time must have same length as first dimension of vectors; len(t)={!r}'.format(len(t)))
+
+     #This constructs the matrix given by Eq. (5.11) of Markley and Crassidis
     S = np.empty((3, 3))
     for i in range(3):
         for j in range(3):
             if t is None:
-                S[i, j] = np.sum(a⃗[..., i] * b⃗[..., j])
+                S[i, j] = np.sum(a_v[..., i] * b_v[..., j])
             else:
-                S[i, j] = spline(t, a⃗[:, i] * b⃗[:, j]).integral(t[0], t[-1])
+                S[i, j] = spline(t, a_v[:, i] * b_v[:, j]).integral(t[0], t[-1])
 
     # This is Eq. (5.17) from Markley and Crassidis, modified to suit our
     # conventions by flipping the sign of ``z``, and moving the final dimension

--- a/src/quaternion/means.py
+++ b/src/quaternion/means.py
@@ -75,8 +75,8 @@ def optimal_alignment_in_chordal_metric(Ra, Rb, t=None):
     return mean_rotor_in_chordal_metric(Ra / Rb, t)
 
 
-def optimal_alignment_in_Euclidean_metric(a_v, b_v, t=None):
-    """Return rotor R such that R*b_v*R̄ is as close to a_v as possible
+def optimal_alignment_in_Euclidean_metric(avec, bvec, t=None):
+    """Return rotor R such that R*b⃗*R̄ is as close to a⃗ as possible
 
     As in the `optimal_alignment_in_chordal_metric` function, the `t` argument is
     optional.  If it is present, the times are used to weight the corresponding
@@ -97,29 +97,27 @@ def optimal_alignment_in_Euclidean_metric(a_v, b_v, t=None):
     from scipy.interpolate import InterpolatedUnivariateSpline as spline
     from . import quaternion
 
-    a_v = np.asarray(a_v, dtype=float)
-    b_v = np.asarray(b_v, dtype=float)
-    if a_v.shape != b_v.shape:
-        #raise ValueError(f'Input vectors must have same shape; a_v.shape={a_v.shape}, b_v.shape={b_v.shape}')
-        raise ValueError('Input vectors must have same shape; a_v.shape={!r}, b_v.shape={!r}'.format(a_v.shape, b_v.shape))
-
-    if a_v.shape[-1] != 3:
-        raise ValueError('Final dimension of a_v and b_v must have size 3; it is {!r}'.format(a_v.shape[-1]))
+    avec = np.asarray(avec, dtype=float)
+    bvec = np.asarray(bvec, dtype=float)
+    if avec.shape != bvec.shape:
+        raise ValueError("Input vectors must have same shape; avec.shape={!r}, bvec.shape={!r}".format(avec.shape, bvec.shape))
+    if avec.shape[-1] != 3:
+        raise ValueError("Final dimension of avec and bvec must have size 3; it is {!r}".format(avec.shape[-1]))
     if t is not None:
-        if a_v.ndim != 2:
-            raise ValueError('If t is not None, a_v and b_v must have exactly 2 dimensions; they have {!r}'.format(a_v.ndim))
+        if avec.ndim != 2:
+            raise ValueError("If t is not None, avec and bvec must have exactly 2 dimensions; they have {!r}".format(avec.ndim))
         t = np.asarray(t, dtype=float)
-        if a_v.shape[0] != len(t):
-            raise ValueError('Input time must have same length as first dimension of vectors; len(t)={!r}'.format(len(t)))
+        if avec.shape[0] != len(t):
+            raise ValueError("Input time must have same length as first dimension of vectors; len(t)={!r}".format(len(t)))
 
-     #This constructs the matrix given by Eq. (5.11) of Markley and Crassidis
+    # This constructs the matrix given by Eq. (5.11) of Markley and Crassidis
     S = np.empty((3, 3))
     for i in range(3):
         for j in range(3):
             if t is None:
-                S[i, j] = np.sum(a_v[..., i] * b_v[..., j])
+                S[i, j] = np.sum(avec[..., i] * bvec[..., j])
             else:
-                S[i, j] = spline(t, a_v[:, i] * b_v[:, j]).integral(t[0], t[-1])
+                S[i, j] = spline(t, avec[:, i] * bvec[:, j]).integral(t[0], t[-1])
 
     # This is Eq. (5.17) from Markley and Crassidis, modified to suit our
     # conventions by flipping the sign of ``z``, and moving the final dimension


### PR DESCRIPTION
This resolves an issue with using the quaternion library with Python 2.7. Before making these changes, the user would receive a message "ModuleNotFoundError: No module named 'quaternion'".

The following changes were made to means.py:
- Replace vector symbols \vec{a} and \vec{b} with a_v and b_v
- Replace formatted strings of form f"str" with 'str'.format().

After making the changes, it was tested with Python 2.7 on Ubuntu 18.04 and worked as expected.