### PR TITLE
Add `assert(PyGILState_Check());` in `QUATERNION_copyswapn()`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
       CIBW_SKIP: cp27-* cp35-* cp36-* cp37-* pp* *-musllinux_aarch64
       CIBW_ARCHS: ${{matrix.archs}}
       CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+      CIBW_ENVIRONMENT: CFLAGS='-DNDEBUG'
       CIBW_BEFORE_BUILD: python -c "print(('#'*130+'\n')*10)" && python -m pip install oldest-supported-numpy
       CIBW_TEST_REQUIRES: pytest pytest-cov
       CIBW_TEST_COMMAND: "pytest {project}/tests"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,6 @@ jobs:
       CIBW_SKIP: cp27-* cp35-* cp36-* cp37-* pp* *-musllinux_aarch64
       CIBW_ARCHS: ${{matrix.archs}}
       CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-      CIBW_ENVIRONMENT: CFLAGS='-DNDEBUG'
       CIBW_BEFORE_BUILD: python -c "print(('#'*130+'\n')*10)" && python -m pip install oldest-supported-numpy
       CIBW_TEST_REQUIRES: pytest pytest-cov
       CIBW_TEST_COMMAND: "pytest {project}/tests"

--- a/src/numpy_quaternion.c
+++ b/src/numpy_quaternion.c
@@ -940,6 +940,7 @@ QUATERNION_copyswapn(quaternion *dst, npy_intp dstride,
                      quaternion *src, npy_intp sstride,
                      npy_intp n, int swap, void *NPY_UNUSED(arr))
 {
+  assert(PyGILState_Check());
   PyArray_Descr *descr;
   descr = PyArray_DescrFromType(NPY_DOUBLE);
   descr->f->copyswapn(&dst->w, dstride, &src->w, sstride, n, swap, NULL);

--- a/src/numpy_quaternion.c
+++ b/src/numpy_quaternion.c
@@ -941,8 +941,9 @@ QUATERNION_copyswapn(quaternion *dst, npy_intp dstride,
                      npy_intp n, int swap, void *NPY_UNUSED(arr))
 {
   if (!PyGILState_Check()) {
-    fprintf(stderr, "PyGILState_Check() failed in QUATERNION_copyswapn()\n");
-    fflush(stderr);
+    fprintf(stdout, "\nPyGILState_Check() failed in QUATERNION_copyswapn()\n");
+    fprintf(stdout, "Calling exit(1)\n\n");
+    fflush(stdout);
     exit(1);
   }
   PyArray_Descr *descr;

--- a/src/numpy_quaternion.c
+++ b/src/numpy_quaternion.c
@@ -940,7 +940,11 @@ QUATERNION_copyswapn(quaternion *dst, npy_intp dstride,
                      quaternion *src, npy_intp sstride,
                      npy_intp n, int swap, void *NPY_UNUSED(arr))
 {
-  assert(PyGILState_Check());
+  if (!PyGILState_Check()) {
+    fprintf(stderr, "PyGILState_Check() failed in QUATERNION_copyswapn()\n");
+    fflush(stderr);
+    exit(1);
+  }
   PyArray_Descr *descr;
   descr = PyArray_DescrFromType(NPY_DOUBLE);
   descr->f->copyswapn(&dst->w, dstride, &src->w, sstride, n, swap, NULL);


### PR DESCRIPTION
I'm working on a systematic cleanup of the extended Google codebase, which imports this github project. Using the patch below in the Google environment, I found a GIL check failure when running test_quaternion.py.

I have not tried this outside the Google environment. Creating this PR to see if that reproduces the failure. (If not I'll explain more.)

```
--- python_runtime/v3_9/Include/object.h
+++ python_runtime/v3_9/Include/object.h
@@ -417,8 +417,11 @@ PyAPI_FUNC(void) _Py_NegativeRefcount(co

 PyAPI_FUNC(void) _Py_Dealloc(PyObject *);

+PyAPI_FUNC(int) PyGILState_Check(void); /* Include/cpython/pystate.h */
+
 static inline void _Py_INCREF(PyObject *op)
 {
+    assert(PyGILState_Check());
 #ifdef Py_REF_DEBUG
     _Py_RefTotal++;
 #endif
@@ -433,6 +436,7 @@ static inline void _Py_DECREF(
 #endif
     PyObject *op)
 {
+    assert(PyGILState_Check());
 #ifdef Py_REF_DEBUG
     _Py_RefTotal--;
 #endif
```