### PR TITLE
Update call to scipy.linalg.eigh to not use deprecated eigvals parameter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.13
-scipy>=0.18.0
+scipy>=1.5.0
 numba>=0.49.1

--- a/src/quaternion/__init__.py
+++ b/src/quaternion/__init__.py
@@ -353,7 +353,7 @@ def from_rotation_matrix(rot, nonorthogonal=True):
 
         if not shape:
             q = zero.copy()
-            eigvals, eigvecs = linalg.eigh(K3.T, eigvals=(3, 3))
+            eigvals, eigvecs = linalg.eigh(K3.T, subset_by_index=(3, 3))
             q.components[0] = eigvecs[-1]
             q.components[1:] = -eigvecs[:-1].flatten()
             return q
@@ -361,7 +361,7 @@ def from_rotation_matrix(rot, nonorthogonal=True):
             q = np.empty(shape+(4,), dtype=np.float64)
             for flat_index in range(reduce(mul, shape)):
                 multi_index = np.unravel_index(flat_index, shape)
-                eigvals, eigvecs = linalg.eigh(K3[multi_index], eigvals=(3, 3))
+                eigvals, eigvecs = linalg.eigh(K3[multi_index], subset_by_index=(3, 3))
                 q[multi_index+(0,)] = eigvecs[-1]
                 q[multi_index+(slice(1,None),)] = -eigvecs[:-1].flatten()
             return as_quat_array(q)


### PR DESCRIPTION
In SciPy 1.5.0 ([released June 21 2020](https://docs.scipy.org/doc/scipy-1.5.0/reference/index.html)) the [scipy.linalg.eigh](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.eigh.html) function was rewritten and a new ``subset_by_index`` parameter was added to replace ``eigvals`` ([entry in release notes](https://docs.scipy.org/doc/scipy-1.5.0/reference/release.1.5.0.html#scipy-linalg-improvements)). The latter will be removed in 1.12.0 and using it is now issuing deprecation warnings. This commit updates calls in `from_rotation_matrix` to use ``subset_by_index``. The minimum version in requirements.txt is also updated to 1.5.0.

Note that `optimal_alignment_in_Euclidean_metric` already uses ``subset_by_index`` so SciPy 1.5.0 or later is already required:
https://github.com/moble/quaternion/blob/a34a20d3aea8757f75bb5c40f448ceb98f513ea2/src/quaternion/means.py#L132-L136
