### PR TITLE
fix quaternion_inverse()

### DIFF
--- a/quaternion.ipynb
+++ b/quaternion.ipynb
@@ -1,0 +1,260 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import quaternion"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "首先构建几个四元数"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(quaternion(1, 2, 3, 4),\n",
+       " quaternion(1, 2, 3, 4),\n",
+       " quaternion(0.965302953583425, -0, 0.256504056173354, 0.0489476962658411),\n",
+       " quaternion(-0.224845095366153, 0.708073418273571, 0.454648713412841, 0.491295496433882))"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q1 = np.quaternion(1,2,3,4)\n",
+    "q2 = quaternion.from_float_array([1,2,3,4])\n",
+    "\n",
+    "# 生成的都是单位四元数\n",
+    "q3 = quaternion.from_rotation_matrix([[1,2,3],[1,2,3],[1,2,3]])\n",
+    "q4 = quaternion.from_euler_angles([1,2,3])\n",
+    "q1,q2,q3,q4"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "四元数叉乘\n",
+    "\n",
+    "$\n",
+    "(w_1,x_1,y_1,z_1) \\otimes (w_2,x_2,y_2,z_2) = \n",
+    "\\begin{matrix}\n",
+    "(&w_1w_2-x_1x_2-y_1y_2-z_1z_2,\\\\&w_1x_2+x_1w_2+z_1y_2-y_1z_2,\\\\&w_1y_2+y_1w_2+x_1z_2-z_1x_2,\\\\&w_1z_2+z_1w_2+y_1x_2-x_1y_2&)\n",
+    "\\end{matrix}\n",
+    "$\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "quaternion(-28, 4, 6, 8)\n",
+      "quaternion(-28, 4, 6, 8)\n",
+      "quaternion(-28, 4, 6, 8)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# dot方法这里也是叉乘 \n",
+    "print(np.dot(q1,q2))\n",
+    "print(q1 * q2)\n",
+    "print(np.multiply(q1,q2))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "四元数的模\n",
+    "\n",
+    "\n",
+    "$\\lVert q \\rVert = \\sqrt{w^2+x^2+y^2+z^2}\n",
+    "$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "30.0\n",
+      "5.477225575051661\n",
+      "5.477225575051661\n",
+      "5.477225575051661\n",
+      "quaternion(0.182574185835055, 0.365148371670111, 0.547722557505166, 0.730296743340221)\n",
+      "quaternion(0.182574185835055, 0.365148371670111, 0.547722557505166, 0.730296743340221)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 注意这里norm是平方和，并不是二范数的概念\n",
+    "print(q1.norm())\n",
+    "# 计算四元数的模\n",
+    "print(np.sqrt(q1.norm()))\n",
+    "print(q1.abs())\n",
+    "print(q1.absolute())\n",
+    "# 四元数的归一化\n",
+    "print(q1 / np.sqrt(q1.norm()))\n",
+    "print(q1.normalized())\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "四元数的共轭就是让四元数的向量部分取负\n",
+    "\n",
+    "$\n",
+    "q^* = (w,x,y,z)^* = (w,-x,-y,-z)\n",
+    "$\n",
+    "\n",
+    "四元数的逆就是四元数的共轭除以它的模\n",
+    "$q^{-1} = \\frac{q^*}{\\lVert q \\rVert}$\n",
+    "\n",
+    "一般用单位四元数，此时它的逆和共轭是相等的"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "quaternion(1, -2, -3, -4)\n",
+      "quaternion(0.182574185835055, -0.365148371670111, -0.547722557505166, -0.730296743340221)\n",
+      "quaternion(0.0333333333333333, -0.0666666666666667, -0.1, -0.133333333333333)\n",
+      "quaternion(0.182574185835055, -0.365148371670111, -0.547722557505166, -0.730296743340221)\n",
+      "quaternion(0.182574185835055, -0.365148371670111, -0.547722557505166, -0.730296743340222)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 四元数求共轭\n",
+    "print(q1.conjugate())\n",
+    "# 四元数求逆\n",
+    "print(q1.conjugate() / q1.abs())\n",
+    "# 注意这里直接用inverse()是有问题的，原代码直接除以平方和，显然是不对的\n",
+    "print(q1.inverse())\n",
+    "\n",
+    "# 单位四元数的共轭和逆是相等的\n",
+    "q_normolized = q1.normalized()\n",
+    "print(q_normolized.conjugate())\n",
+    "print(q_normolized.conjugate() / q_normolized.abs())"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "两个四元数间的旋转量，表示一个方位到另一个方位的旋转量\n",
+    "$q = q_{begin}^* * q_{after}$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "quaternion(-0.0763766127950828, 0.579740081530185, 0.461888862260852, 0.66687834708041)\n",
+      "quaternion(-0.224845095366153, 0.411176207749996, 0.397894830565094, 0.788706861311409)\n",
+      "quaternion(-0.224845095366153, 0.708073418273571, 0.454648713412841, 0.491295496433882)\n",
+      "quaternion(-0.224845095366153, 0.708073418273571, 0.454648713412841, 0.491295496433882)\n"
+     ]
+    }
+   ],
+   "source": [
+    "q = q3.conjugate() * q4\n",
+    "print(q)\n",
+    "# 要注意四元数叉乘顺序\n",
+    "print(q * q3)\n",
+    "print(q3 * q)\n",
+    "print(q4)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "四元数点乘，用于度量两个四元数的相似性\n",
+    "\n",
+    "和向量的点乘类似，两四元数点乘绝对值越大其代表的旋转约相似，点乘趋近于-1或者1，都意味着相似，因为$(1,0,0,0)$和$(-1,0,0,0)$的意义是当旋转角为360度的整数倍时，方位没有改变"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 在quaternion库中没有对应的方法\n",
+    "def quatDot(q1,q2):\n",
+    "    return np.abs((q1.w * q2.w + q1.x * q2.x + q1.y * q2.y + q1.z * q2.z) / q1.absolute()*q2.absolute() )"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "ad2bdc8ecc057115af97d19610ffacc2b4e99fae6737bb82f5d7fb13d2f2c186"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/quaternion.h
+++ b/src/quaternion.h
@@ -189,8 +189,8 @@ extern "C" {
     return r;
   }
   static NPY_INLINE quaternion quaternion_inverse(quaternion q) {
-    double norm = quaternion_norm(q);
-    quaternion r = {q.w/norm, -q.x/norm, -q.y/norm, -q.z/norm};
+    double abs = quaternion_absolute(q);
+    quaternion r = {q.w/abs, -q.x/abs, -q.y/abs, -q.z/abs};
     return r;
   }
 


### PR DESCRIPTION
When I was using this library, I found that there was a problem with the inverse of the quaternion.
The proper usage is :$q^{-1} = \frac{q^*}{\lVert q \rVert}$. I find a mistake in this repo. The func '**quaternion_norm**' is different from the '**np.linalg.norm**'. In order to reduce changes, I change the func '**quaternion_norm**' to '**quaternion_absolute**' which is the same as the usage of '**np.linalg.norm**'.