### PR TITLE
Fix indexing of eigen vector

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Create release
         if: "!contains(github.event.head_commit.message, '[no release]')"
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/src/quaternion/__init__.py
+++ b/src/quaternion/__init__.py
@@ -362,7 +362,7 @@ def from_rotation_matrix(rot, nonorthogonal=True):
             for flat_index in range(reduce(mul, shape)):
                 multi_index = np.unravel_index(flat_index, shape)
                 eigvals, eigvecs = linalg.eigh(K3[multi_index], subset_by_index=(3, 3))
-                q[multi_index+(0,)] = eigvecs[-1]
+                q[multi_index+(0,)] = eigvecs[-1, 0]
                 q[multi_index+(slice(1,None),)] = -eigvecs[:-1].flatten()
             return as_quat_array(q)
 

--- a/src/quaternion/__init__.py
+++ b/src/quaternion/__init__.py
@@ -354,7 +354,7 @@ def from_rotation_matrix(rot, nonorthogonal=True):
         if not shape:
             q = zero.copy()
             eigvals, eigvecs = linalg.eigh(K3.T, subset_by_index=(3, 3))
-            q.components[0] = eigvecs[-1]
+            q.components[0] = eigvecs[-1, 0]
             q.components[1:] = -eigvecs[:-1].flatten()
             return q
         else:


### PR DESCRIPTION
`from_rotation_matrix` causes deprecation warning. It is because `linalg.eigh` returns a 2D ndarray. I fixed its indexing.

The simplest code to check is below:

```
import warnings
import numpy as np
import quaternion

warnings.simplefilter("default")                                                                                                                                                                                   
quaternion.from_rotation_matrix(np.eye(3))
```

And the warning message:
```
/home/unno/git/quaternion/src/quaternion/__init__.py:357: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  q.components[0] = eigvecs[-1]
```