### PR TITLE
Enable 'pip install' under Cygwin platform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
 # Set appropriate optimization flags
-if "win" in platform.lower() and not "darwin" in platform.lower():
+if "win" in platform.lower() and platform.lower() != 'cygwin' and not "darwin" in platform.lower():
     extra_compile_args = ["/O2"]
 else:
     extra_compile_args = ["-O3", "-w"]


### PR DESCRIPTION
Installation under the Cygwin platform (Windows 10 or 11, Cygwin version 3.6.3, Python version 3.9.16, NumPy version 1.26.4, GCC version 12.4.0) fails with the following error message:

```
$ pip install --no-clean --upgrade --force-reinstall numpy-quaternion
Defaulting to user installation because normal site-packages is not writeable
Collecting numpy-quaternion
  Using cached numpy-quaternion-2023.0.4.tar.gz (65 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting numpy<2.0,>=1.13 (from numpy-quaternion)
  Downloading numpy-1.26.4.tar.gz (15.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 15.8/15.8 MB 50.4 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: numpy-quaternion, numpy
  Building wheel for numpy-quaternion (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Building wheel for numpy-quaternion (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [16 lines of output]
      running bdist_wheel
      running build
      running build_py
      creating build/lib.cygwin-3.6.3-x86_64-cpython-39/quaternion
      copying src/quaternion/calculus.py -> build/lib.cygwin-3.6.3-x86_64-cpython-39/quaternion
      copying src/quaternion/means.py -> build/lib.cygwin-3.6.3-x86_64-cpython-39/quaternion
      copying src/quaternion/numba_wrapper.py -> build/lib.cygwin-3.6.3-x86_64-cpython-39/quaternion
      copying src/quaternion/quaternion_time_series.py -> build/lib.cygwin-3.6.3-x86_64-cpython-39/quaternion
      copying src/quaternion/__init__.py -> build/lib.cygwin-3.6.3-x86_64-cpython-39/quaternion
      running build_ext
      building 'quaternion.numpy_quaternion' extension
      creating build/temp.cygwin-3.6.3-x86_64-cpython-39/src
      gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -I/tmp/pip-build-env-4j96utkg/overlay/lib/python3.9/site-packages/numpy/core/include -Isrc -I/usr/include/python3.9 -c src/numpy_quaternion.c -o build/temp.cygwin-3.6.3-x86_64-cpython-39/src/numpy_quaternion.o /O2
      gcc: warning: /O2: linker input file unused because linking not done
      gcc: error: /O2: linker input file not found: No such file or directory
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for numpy-quaternion
  Building wheel for numpy (pyproject.toml) ... done
  Created wheel for numpy: filename=numpy-1.26.4-cp39-cp39-cygwin_3_6_3_x86_64.whl size=9069960 sha256=4a0b0bb3399a85c7b3bfa25ead17b444d16923762430842a09dab614f534bae9
  Stored in directory: /home/TANNHAUSER/.cache/pip/wheels/fd/19/e1/520405de003fa7559be24cc329162d0ecfbc8531f1166151e9
Successfully built numpy
Failed to build numpy-quaternion
ERROR: Failed to build installable wheels for some pyproject.toml based projects (numpy-quaternion)
```
Problem: The option `/O2` is dedicated to MSVC while Cygwin GCC requires `-O3` for enabling the highest optimisation level.
This pull request fixes the problem. It is based on numpy-quaternion release 2023.0.4. The patch should also be integrated into the main branch, which would be testable once Cygwin provides stable Python 3.12 support + NumPy update.